### PR TITLE
Default versions from olm utils

### DIFF
--- a/automation-generators/generic/cp4d/preprocessor.py
+++ b/automation-generators/generic/cp4d/preprocessor.py
@@ -1,5 +1,6 @@
 from generatorPreProcessor import GeneratorPreProcessor
 import sys, os
+import re
 
 # Reference
 # ---
@@ -32,7 +33,7 @@ import sys, os
 #cp4d:
 #- project: zen-40
 #  openshift_cluster_name: sample
-#  cp4d_version: 4.0
+#  cp4d_version: 4.0.9
 #  openshift_storage_name: nfs-storage
 #  use_case_files: True
 #  accept_licenses: False
@@ -242,6 +243,10 @@ def preprocessor(attributes=None, fullConfig=None):
         # Check for cp4d:     
         # Check that cpfs element exists
         # Check that cpd_platform element exists
+
+        # Check that version matches x.y.z pattern
+        if not re.match(r"[0-9]\.[0-9]\.[0-9]+",str(ge['cp4d_version'])):
+            g.appendError(msg="cp4d_version must be in the format of x.y.z, for example 4.0.9")
 
         # Check accept_licenses property
         if 'accept_licenses' in ge:

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/files/check-services-installed.sh
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/files/check-services-installed.sh
@@ -13,7 +13,7 @@
 status_dir=$1
 project=$2
 cartridges=$(cat ${status_dir}/log/${project}-cartridges.json)
-current_cartridge_name=$4
+current_cartridge_name=$3
 
 exit_code=0
 number_pending=0

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/files/check-services-installed.sh
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/files/check-services-installed.sh
@@ -3,9 +3,7 @@
 # Parameters
 # $1: Status directory
 # $2: OpenShift project for Cloud Pak for Data
-# $3: List of cartridges which are being installed
-# $4: List of all cartridges with their CR name and status
-# $5: Name of the cartridge to be checked
+# $3: Name of the cartridge to be checked
 
 # The script loops through all cartridges which are being installed and checks the CR status for each.
 # It also checks the installation state of the current cartridge. If installation of the current cartridge
@@ -14,7 +12,7 @@
 # If the CR of a cartridge does not exist, the script fails with exit code 1.
 status_dir=$1
 project=$2
-cartridges=$(echo $3 | base64 -d)
+cartridges=$(cat ${status_dir}/log/${project}-cartridges.json)
 current_cartridge_name=$4
 
 exit_code=0

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/tasks/cp4d-wait-cartridges-ready.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/tasks/cp4d-wait-cartridges-ready.yml
@@ -3,12 +3,16 @@
     msg: "{{ _current_cp4d_cartridge }}"
 
 - block:
+  - name: Write cartridge information to file {{ status_dir }}/log/{{ _p_current_cp4d_cluster.project }}-cartridges.json
+    copy:
+      content: "{{ _cartridges_to_install | default([]) | to_json }}"
+      dest: "{{ status_dir }}/log/{{ _p_current_cp4d_cluster.project }}-cartridges.json"
+
   - name: Wait until cartridge {{ _current_cp4d_cartridge.name }} has been installed, check logs in {{ status_dir }}/log/{{ _p_current_cp4d_cluster.project }}-cartridges.log
     script: |
       check-services-installed.sh \
         {{ status_dir }} \
         {{ _p_current_cp4d_cluster.project }} \
-        {{ _cartridges_to_install | default([]) | to_json | b64encode }} \
         {{ _current_cp4d_cartridge.name }}
         
     register: _wait_cartridges_result

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/tasks/main.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
 - include_role:
     name: cp4d-variables
-  vars:
-    _p_cartridges: "{{ _p_current_cp4d_cluster.cartridges }}"
     
 - include_tasks: cp4d-install-cartridges.yml
   when: not (_p_current_cp4d_cluster.olm_utils | default(False) | bool)

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/analyticsengine-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/analyticsengine-cr.j2
@@ -7,9 +7,7 @@ spec:
   license:
     accept: {{ _cpd_accept_licenses | default(False) }}
     license: Enterprise
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}
 {% if selected_openshift_storage.storage_type == "pwx" %}
   storageVendor: portworx
   storage_class: portworx-shared-gp3

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/bigsql-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/bigsql-cr.j2
@@ -19,6 +19,4 @@ spec:
 {% else %} 
   storageClass: {{ ocp_storage_class_file }}
 {% endif %}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/ca-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/ca-cr.j2
@@ -13,6 +13,4 @@ spec:
 {% else %} 
   storage_class: {{ ocp_storage_class_file }}
 {% endif %}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/cde-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/cde-cr.j2
@@ -12,6 +12,4 @@ spec:
 {% else %} 
   storageClass: {{ ocp_storage_class_file }}
 {% endif %}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/datagate-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/datagate-cr.j2
@@ -14,6 +14,4 @@ spec:
 {% else %} 
   storageClass: {{ ocp_storage_class_file }}
 {% endif %}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/datastage-ent-plus-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/datastage-ent-plus-cr.j2
@@ -7,11 +7,9 @@ spec:
   license:
     accept: {{ _cpd_accept_licenses | default(False) }}
     license: Enterprise
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
 {% if selected_openshift_storage.storage_type == "pwx" %}
   storageClass: portworx-shared-gp3
 {% else %} 
   storageClass: {{ ocp_storage_class_file }}
 {% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/db2-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/db2-cr.j2
@@ -8,6 +8,3 @@ spec:
   license:
     accept: {{ _cpd_accept_licenses | default(False) }}
     license: Advanced
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/db2aaservice-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/db2aaservice-cr.j2
@@ -12,6 +12,4 @@ spec:
   storageOverride:
   license:
     accept: {{ _cpd_accept_licenses | default(False) }}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/db2wh-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/db2wh-cr.j2
@@ -7,6 +7,3 @@ spec:
   license:
     accept: {{ _cpd_accept_licenses | default(False) }}
     license: Enterprise
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}    

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/dmc-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/dmc-cr.j2
@@ -7,6 +7,4 @@ spec:
   license:
     accept: {{ _cpd_accept_licenses | default(False) }}
     license: Enterprise
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/dods-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/dods-cr.j2
@@ -7,6 +7,4 @@ spec:
   license:
     accept: {{ _cpd_accept_licenses | default(False) }}
     license: Enterprise
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/dp-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/dp-cr.j2
@@ -7,6 +7,4 @@ spec:
   license:
     accept: {{ _cpd_accept_licenses | default(False) }}
     license: Enterprise
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/dv-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/dv-cr.j2
@@ -8,7 +8,4 @@ spec:
     accept: {{ _cpd_accept_licenses | default(False) }}
     license: Enterprise
   size: {{ _current_cp4d_cartridge.size }}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
-
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/hadoop-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/hadoop-cr.j2
@@ -9,12 +9,10 @@ spec:
   license:
     accept: {{ _cpd_accept_licenses | default(False) }}
     license: Enterprise
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
 {% if selected_openshift_storage.storage_type == "pwx" %}
   storageVendor: portworx
   storageClass: portworx-shared-gp3
 {% else %}
   storageClass: {{ ocp_storage_class_file }}
 {% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/iis-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/iis-cr.j2
@@ -16,6 +16,4 @@ spec:
   use_dynamic_provisioning: true
   cert_manager_enabled: true
   # iis_db2u_set_kernel_params: True
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/mdm-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/mdm-cr.j2
@@ -21,6 +21,4 @@ spec:
 {% endif %}
   wkc:
     enabled: {{ _current_cp4d_cartridge.wkc_enabled }}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/openpages-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/openpages-cr.j2
@@ -12,6 +12,4 @@ spec:
   license:
     accept: {{ _cpd_accept_licenses | default(False) }}
     license: Enterprise
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/planning-analytics-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/planning-analytics-cr.j2
@@ -12,7 +12,4 @@ metadata:
 spec:
   license:
     accept: {{ _cpd_accept_licenses | default(False) }}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
-  
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/productmaster-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/productmaster-cr.j2
@@ -17,6 +17,4 @@ spec:
   registry_secret_name: ""
   app_secret_name: "app-secret"
   domain_name: ""
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/rstudio-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/rstudio-cr.j2
@@ -13,6 +13,4 @@ spec:
   license:
     license: Enterprise
     accept: {{ _cpd_accept_licenses | default(False) }}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/spss-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/spss-cr.j2
@@ -16,6 +16,4 @@ spec:
 {% else %}  
   storageClass: {{ ocp_storage_class_file }}
 {% endif %}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/voice-gateway-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/voice-gateway-cr.j2
@@ -25,6 +25,4 @@ spec:
       limits:
         cpu: "0.5"
         memory: 1Gi 
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}        
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/watson-assistant-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/watson-assistant-cr.j2
@@ -338,6 +338,4 @@ spec:
   license:
     accept: {{ _cpd_accept_licenses | default(False) }}
   size: {{ _current_cp4d_cartridge.size }}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/watson-discovery-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/watson-discovery-cr.j2
@@ -17,6 +17,4 @@ spec:
 {% endif %}
   watsonGateway:
     version: main
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/watson-ks-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/watson-ks-cr.j2
@@ -14,6 +14,4 @@ spec:
   awt:
     persistentVolume: 
       storageClassName: {{ ocp_storage_class_file }}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/watson-openscale-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/watson-openscale-cr.j2
@@ -14,6 +14,4 @@ spec:
 {% else %}
   storageClass: {{ ocp_storage_class_file }}
 {% endif %}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/watson-speech-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/watson-speech-cr.j2
@@ -6,9 +6,7 @@ metadata:
 spec:
   license:
     accept: {{ _cpd_accept_licenses | default(False) }}
-{% if _current_cp4d_cartridge.version is defined %}
-    version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}
 ################
 # Storage class
 ################

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/wkc-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/wkc-cr.j2
@@ -84,6 +84,4 @@ spec:
 {% endif %}
   # install_wkc_core_only: true     # To install the core version of the service, remove the comment tagging from the beginning of the line.
   # wkc_db2u_set_kernel_params: True     
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/wml-accelerator-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/wml-accelerator-cr.j2
@@ -8,6 +8,4 @@ spec:
   cpdNamespace: {{ _p_current_cp4d_cluster.project }}
   serviceReplicas: {{ _current_cp4d_cartridge.replicas }}
   scaleConfig: {{ _current_cp4d_cartridge.size }}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/wml-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/wml-cr.j2
@@ -16,6 +16,4 @@ spec:
   storageVendor: "" 
   storageClass: {{ ocp_storage_class_file }}
 {% endif %}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/wsl-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/wsl-cr.j2
@@ -13,6 +13,4 @@ spec:
 {% else %}
   storageClass: {{ ocp_storage_class_file }}
 {% endif %}
-{% if _current_cp4d_cartridge.version is defined %}
-  version: {{ _current_cp4d_cartridge.version }}
-{% endif %}
+  version: {{ _current_cp4d_cartridge.version | default(_current_cp4d_cartridge.CR_Version) }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-remove/tasks/main.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-remove/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
 - include_role:
     name: cp4d-variables
-  vars:
-    _p_cartridges: "{{ _p_current_cp4d_cluster.cartridges }}"
 
 - name: Remove obsolete cartridges from CP4D cluster {{ _p_current_cp4d_cluster.project }}
   debug:

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-case-save/tasks/download-case-file.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-case-save/tasks/download-case-file.yml
@@ -12,7 +12,7 @@
     debug:
       var: _case_save_command
 
-  - name: Save case file {{ _current_cp4d_cartridge.search_string }}-{{ _current_cp4d_cartridge.case_version }}
+  - name: Save case file {{ _current_cp4d_cartridge.search_string }}-{{ _current_cp4d_cartridge.case_version | default(_current_cp4d_cartridge.CASE_Version) }}
     shell: |
       {{ _case_save_command }}
     register: _case_save

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-case-save/tasks/main.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-case-save/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
 - include_role:
     name: cp4d-variables
-  vars:
-    _p_cartridges: "{{ _p_current_cp4d_cluster.cartridges }}"
     
 - set_fact:
     _case_dir: "{{ status_dir }}/cp4d/case"

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-case-save/templates/case-save-command.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-case-save/templates/case-save-command.j2
@@ -1,5 +1,5 @@
 cloudctl case save \
     --repo {{ case_github_url }} \
     --case {{ _current_cp4d_cartridge.search_string }} \
-    --version {{ _current_cp4d_cartridge.case_version }} \
+    --version {{ _current_cp4d_cartridge.case_version | default(_current_cp4d_cartridge.CASE_Version) }} \
     --outputdir {{ _case_dir }} {% if not (_current_cp4d_cartridge.download_dependent_case | default(True) | bool) %} --no-dependency {% endif %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-catalog-source/tasks/main.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-catalog-source/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
 - include_role:
     name: cp4d-variables
-  vars:
-    _p_cartridges: "{{ _p_current_cp4d_cluster.cartridges }}"
 
 - include_tasks: create-catalog-source-ibm-operator-catalog.yml
   when: not _use_case_files

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cluster/tasks/main.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cluster/tasks/main.yml
@@ -6,7 +6,7 @@
 - include_role:
     name: cp4d-variables
   vars:
-    _p_cartridges: "{{ current_cp4d_cluster.cartridges }}"
+    _p_current_cp4d_cluster: "{{ current_cp4d_cluster }}"
 
 - set_fact:
     _cpd_accept_licenses: "{{ current_cp4d_cluster.accept_licenses | default(cpd_accept_licenses) | default(False) }}"

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cluster/templates/list-components-olm-utils.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cluster/templates/list-components-olm-utils.j2
@@ -1,2 +1,0 @@
-/opt/ansible/bin/list-components \
-    --release={{ current_cp4d_cluster.cp4d_version }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-scheduling-service/tasks/main.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-scheduling-service/tasks/main.yml
@@ -1,13 +1,10 @@
 ---
 # Check if the scheduler must be installed
 - set_fact:
-    _scheduler: "{{ _p_current_cp4d_cluster.cartridges | json_query(query) | first | default({}) }}"
+    _scheduler: "{{ _cartridges_to_install | json_query(query) | first | default({}) }}"
   vars:
     query: >-
       [?name=='scheduler']
-
-- debug:
-    var: _p_current_cp4d_cluster.cartridges
 
 - debug:
     var: _scheduler

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-scheduling-service/templates/scheduler-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-scheduling-service/templates/scheduler-cr.j2
@@ -6,9 +6,7 @@ metadata:
   name: ibm-cpd-scheduler
   namespace: {{ _p_fs_project }}
 spec:
-{% if _scheduler.version is defined %}
-  version: {{ _scheduler.version }}
-{% endif %}
+  version: {{ _scheduler.version | default(_scheduler.CR_Version) }}
   license:
     accept: true
   registry: cp.icr.io/cp/cpd

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/tasks/cp4d-create-subscription.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/tasks/cp4d-create-subscription.yml
@@ -11,6 +11,15 @@
 
   # Create of Subscription if not cpd_platform or cpfs
   - block:
+    - name: Obtain packagemanifest {{ _current_cp4d_cartridge.package_manifest }} for cartridge {{ _current_cp4d_cartridge.name }}
+      shell: |
+        oc get packagemanifest {{ _current_cp4d_cartridge.package_manifest }} -o jsonpath="{.status.defaultChannel}"
+      register: _package_manifest
+    
+    - name: Extract default channel for operator
+      set_fact:
+        _default_channel: "{{ _package_manifest.stdout }}"
+
     - name: Prepare yaml file for operator subscription {{ _current_cp4d_cartridge.name }}
       template:
         src: "{{ _current_cp4d_cartridge.cr_file_prefix }}-sub.j2"

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/tasks/cp4d-create-subscription.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/tasks/cp4d-create-subscription.yml
@@ -15,6 +15,9 @@
       shell: |
         oc get packagemanifest {{ _current_cp4d_cartridge.package_manifest }} -o jsonpath="{.status.defaultChannel}"
       register: _package_manifest
+      retries: 30
+      delay: 10
+      until: _package_manifest.rc==0
     
     - name: Extract default channel for operator
       set_fact:

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/tasks/cp4d-create-subscriptions.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/tasks/cp4d-create-subscriptions.yml
@@ -10,6 +10,9 @@
   shell: |
     oc get packagemanifest {{ _cpd_platform.package_manifest }} -o jsonpath="{.status.defaultChannel}"
   register: _cpd_platform_package_manifest
+  retries: 30
+  delay: 10
+  until: _cpd_platform_package_manifest.rc==0
 
 - name: Extract default channel for operator
   set_fact:

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/tasks/cp4d-create-subscriptions.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/tasks/cp4d-create-subscriptions.yml
@@ -1,5 +1,20 @@
 ---
-# Create platform operator subscription
+- name: Get package manifest name for platform operator
+  set_fact:
+    _cpd_platform: "{{ cartridge_cr | json_query(query) | first }}"
+  vars:
+    query: >-
+      [?olm_utils_name=='cpd_platform']
+
+- name: Obtain packagemanifest {{ _cpd_platform.package_manifest }} for platform operator
+  shell: |
+    oc get packagemanifest {{ _cpd_platform.package_manifest }} -o jsonpath="{.status.defaultChannel}"
+  register: _cpd_platform_package_manifest
+
+- name: Extract default channel for operator
+  set_fact:
+    _default_channel: "{{ _cpd_platform_package_manifest.stdout }}"
+
 - name: Prepare yaml file for platform operator subscription
   template:
     src: cpd-platform-subscription.j2

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/tasks/main.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
 - include_role:
     name: cp4d-variables
-  vars:
-    _p_cartridges: "{{ _p_current_cp4d_cluster.cartridges }}"
 
 # Create Foundational Services project for Cloud Pak for Data
 - name: Create OpenShift Project {{ foundational_services_project }} if it does not exist

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/analyticsengine-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/analyticsengine-sub.j2
@@ -8,7 +8,7 @@ metadata:
   name: ibm-cpd-ae-operator-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: analyticsengine-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/bigsql-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/bigsql-sub.j2
@@ -4,7 +4,7 @@ metadata:
   name: ibm-bigsql-operator-catalog-subscription
   namespace: {{ foundational_services_project }}
 spec:   
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-bigsql-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/ca-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/ca-sub.j2
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: ibm-ca-operator
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   name: ibm-ca-operator
   installPlanApproval: Automatic
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/cde-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/cde-sub.j2
@@ -8,7 +8,7 @@ metadata:
   name: ibm-cde-operator-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-cde-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/cpd-platform-subscription.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/cpd-platform-subscription.j2
@@ -4,7 +4,7 @@ metadata:
   name: cpd-operator
   namespace: {{ foundational_services_project }}
 spec:
-  channel: v2.0
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: cpd-platform-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/datagate-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/datagate-sub.j2
@@ -8,7 +8,7 @@ metadata:
   name: ibm-datagate-operator-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-datagate-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/datastage-ent-plus-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/datastage-ent-plus-sub.j2
@@ -4,7 +4,7 @@ metadata:
   name: ibm-cpd-datastage-operator-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-cpd-datastage-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/db2-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/db2-sub.j2
@@ -4,7 +4,7 @@ metadata:
   name: ibm-db2oltp-cp4d-operator-catalog-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   name: ibm-db2oltp-cp4d-operator
   installPlanApproval: Automatic
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/db2aaservice-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/db2aaservice-sub.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ foundational_services_project }}
   generation: 1
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   name: ibm-db2aaservice-cp4d-operator
   installPlanApproval: Automatic
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/db2u-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/db2u-sub.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ foundational_services_project }}
   generation: 1
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   name: db2u-operator
   installPlanApproval: Automatic
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/db2wh-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/db2wh-sub.j2
@@ -4,7 +4,7 @@ metadata:
   name: ibm-db2wh-cp4d-operator-catalog-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   name: ibm-db2wh-cp4d-operator
   installPlanApproval: Automatic
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/dmc-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/dmc-sub.j2
@@ -4,7 +4,7 @@ metadata:
   name: ibm-dmc-operator-subscription 
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   name: ibm-dmc-operator
   installPlanApproval: Automatic
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/dods-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/dods-sub.j2
@@ -8,7 +8,7 @@ metadata:
   name: ibm-cpd-dods-operator-catalog-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   name: ibm-cpd-dods
   installPlanApproval: Automatic
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/dp-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/dp-sub.j2
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ foundational_services_project }}
   name: ibm-cpd-dp-operator-catalog-subscription
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-cpd-dp
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/dv-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/dv-sub.j2
@@ -4,7 +4,7 @@ metadata:
   name: ibm-dv-operator-catalog-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-dv-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/hadoop-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/hadoop-sub.j2
@@ -8,7 +8,7 @@ metadata:
   name: ibm-cpd-hadoop-operator-catalog-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-cpd-hadoop
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/mdm-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/mdm-sub.j2
@@ -8,7 +8,7 @@ metadata:
   name: ibm-mdm-operator-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   name: ibm-mdm
   installPlanApproval: Automatic
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/openpages-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/openpages-sub.j2
@@ -4,7 +4,7 @@ metadata:
   name: ibm-cpd-openpages-operator
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-cpd-openpages-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/planning-analytics-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/planning-analytics-sub.j2
@@ -4,7 +4,7 @@ metadata:
   name: ibm-planning-analytics-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-planning-analytics-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/productmaster-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/productmaster-sub.j2
@@ -4,7 +4,7 @@ metadata:
   name: ibm-productmaster-catalog-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-cpd-productmaster
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/rstudio-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/rstudio-sub.j2
@@ -8,7 +8,7 @@ metadata:
   name: ibm-cpd-rstudio-operator-catalog-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-cpd-rstudio
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/scheduler-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/scheduler-sub.j2
@@ -4,7 +4,7 @@ metadata:
   name: ibm-cpd-scheduling-catalog-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-cpd-scheduling-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/spss-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/spss-sub.j2
@@ -8,7 +8,7 @@ metadata:
   name: ibm-cpd-spss-operator-catalog-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-cpd-spss
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/voice-gateway-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/voice-gateway-sub.j2
@@ -4,7 +4,7 @@ metadata:
   name: ibm-voice-gateway-operator-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-voice-gateway-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/watson-assistant-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/watson-assistant-sub.j2
@@ -16,7 +16,7 @@ metadata:
   name: ibm-watson-assistant-operator-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-watson-assistant-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/watson-discovery-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/watson-discovery-sub.j2
@@ -20,7 +20,7 @@ metadata:
   name: ibm-watson-discovery-operator-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-watson-discovery-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/watson-ks-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/watson-ks-sub.j2
@@ -20,7 +20,7 @@ metadata:
   name: ibm-watson-ks-operator-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-watson-ks-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/watson-openscale-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/watson-openscale-sub.j2
@@ -8,7 +8,7 @@ metadata:
   name: ibm-watson-openscale-operator-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-cpd-wos
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/watson-speech-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/watson-speech-sub.j2
@@ -16,7 +16,7 @@ metadata:
   name: ibm-watson-speech-operator-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-watson-speech-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/wkc-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/wkc-sub.j2
@@ -8,7 +8,7 @@ metadata:
   name: ibm-cpd-wkc-operator-catalog-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-cpd-wkc
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/wml-accelerator-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/wml-accelerator-sub.j2
@@ -4,7 +4,7 @@ metadata:
   name: ibm-cpd-wml-accelerator-operator
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-cpd-wml-accelerator-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/wml-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/wml-sub.j2
@@ -8,7 +8,7 @@ metadata:
   name: ibm-cpd-wml-operator-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-cpd-wml-operator
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/wsl-sub.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-subscriptions/templates/wsl-sub.j2
@@ -5,7 +5,7 @@ metadata:
   name: ibm-cpd-ws-operator-catalog-subscription
   namespace: {{ foundational_services_project }}
 spec:
-  channel: {{ _current_cp4d_cartridge.subscription_channel }}
+  channel: {{ _current_cp4d_cartridge.subscription_channel | default(_default_channel) }}
   installPlanApproval: Automatic
   name: ibm-cpd-wsl
 {% if not (_use_case_files | bool) %}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-variables/tasks/list-components-olm-utils.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-variables/tasks/list-components-olm-utils.yml
@@ -1,0 +1,35 @@
+---
+- name: Ensure that OLM utils work directory exists
+  file:
+    path: /tmp/work
+    state: directory
+
+- name: Generate OLM command to list components for version {{ _p_current_cp4d_cluster.cp4d_version }}
+  set_fact:
+    _list_components_command: "{{ lookup('template', 'list-components-olm-utils.j2') }}" 
+
+- name: Show list-components command
+  debug:
+    var: _list_components_command
+
+- name: Run list-components command 
+  shell: |
+    {{ _list_components_command }}
+
+- name: Get column headers
+  shell: |
+    head -1 /tmp/work/components.csv
+  register: _csv_column_headers
+
+- name: Remove first line from file
+  lineinfile:
+    path: /tmp/work/components.csv
+    regexp: "^Component name"
+    state: absent
+
+- name: Try to convert to json
+  read_csv:
+    path: /tmp/work/components.csv
+    fieldnames: "{{ _csv_column_headers.stdout | replace(' ','_') }}"
+    skipinitialspace: True
+  register: _list_components_json

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-variables/tasks/main.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-variables/tasks/main.yml
@@ -8,10 +8,13 @@
 - set_fact:
     _cartridges_to_install: []
 
+- name: Obtain versions of case files and cartridges
+  include_tasks: list-components-olm-utils.yml
+
 - name: Get cartridges with CR details
   set_fact:
-    _cartridges_to_install: >-
-      {{ _cartridges_to_install | default([]) 
+    _cartridges_with_olm_utils_name: >-
+      {{ _cartridges_with_olm_utils_name | default([]) 
         + [ item | combine(_cartridge_cr_item) | combine(_cartridge_olm_utils_item) ]
       }}
   vars:
@@ -29,4 +32,24 @@
             | first
             | default([])
           }}
-  loop: "{{ _p_cartridges }}"
+  loop: "{{ _p_current_cp4d_cluster.cartridges }}"
+
+- name: Add versions details from olm-utils
+  set_fact:
+    _cartridges_to_install: >-
+      {{ _cartridges_to_install | default([]) 
+        + [ item | combine(_list_components_json_item) ]
+      }}
+  vars:
+    _list_components_json_item: >-
+          {{ _list_components_json.list
+            | selectattr('Component_name','equalto',item['olm_utils_name'])
+            | list
+            | first
+            | default([])
+          }}
+  loop: "{{ _cartridges_with_olm_utils_name }}"
+
+- name: Show full cartridge information
+  debug:
+    var: _cartridges_to_install

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-variables/tasks/main.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-variables/tasks/main.yml
@@ -6,10 +6,12 @@
     var: implemented_cloud_platform_types
 
 - set_fact:
+    _cartridges_with_olm_utils_name: []
     _cartridges_to_install: []
 
 - name: Obtain versions of case files and cartridges
   include_tasks: list-components-olm-utils.yml
+  when: _list_components_json is not defined
 
 - name: Get cartridges with CR details
   set_fact:

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-variables/templates/list-components-olm-utils.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-variables/templates/list-components-olm-utils.j2
@@ -1,0 +1,2 @@
+/opt/ansible/bin/list-components \
+    --release={{ _p_current_cp4d_cluster.cp4d_version }}

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-variables/vars/vars-cp4d-installation.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-variables/vars/vars-cp4d-installation.yml
@@ -16,6 +16,7 @@ cartridge_cr:
     olm_utils_name: cpd_platform
     inventory: cpdPlatformOperator
     search_string: ibm-cp-datacore
+    package_manifest: cpd-platform-operator
     cr_cr: ZenService
     cr_name: lite-cr
     cr_status_attribute: zenStatus
@@ -25,12 +26,14 @@ cartridge_cr:
     olm_utils_name: cpfs
     inventory: ibmCommonServiceOperatorSetup
     search_string: ibm-cp-common-services
+    package_manifest: ibm-common-service-operator
     download_dependent_case: True
   - name: scheduler
     cr_file_prefix: scheduler
     olm_utils_name: scheduler
     inventory: schedulerSetup
     search_string: ibm-cpd-scheduling
+    package_manifest: ibm-cpd-scheduling-operator
     cartridge_label: operators.coreos.com/ibm-cpd-scheduling-operator.ibm-common-services
     download_dependent_case: True
   - name: analyticsengine
@@ -38,6 +41,7 @@ cartridge_cr:
     olm_utils_name: analyticsengine
     inventory: analyticsengineOperatorSetup
     search_string: ibm-analyticsengine
+    package_manifest: analyticsengine-operator
     cartridge_label: operators.coreos.com/analyticsengine-operator.ibm-common-services
     cr_cr: AnalyticsEngine
     cr_name: analyticsengine-sample
@@ -50,6 +54,7 @@ cartridge_cr:
     olm_utils_name: bigsql
     inventory: bigsql
     search_string: ibm-bigsql-case
+    package_manifest: ibm-bigsql-operator
     cartridge_label: operators.coreos.com/ibm-bigsql-operator.ibm-common-services
     cr_cr: BigsqlService
     cr_name: bigsql-service-cr
@@ -64,6 +69,7 @@ cartridge_cr:
     olm_utils_name: cognos_analytics
     inventory: ibmCaOperatorSetup
     search_string: ibm-cognos-analytics-prod
+    package_manifest: ibm-ca-operator
     cartridge_label: operators.coreos.com/ibm-ca-operator.ibm-common-services
     cr_cr: CAService
     cr_name: ca-addon-cr
@@ -76,6 +82,7 @@ cartridge_cr:
   - name: ccs
     olm_utils_name: ccs
     search_string: ibm-ccs
+    package_manifest: ibm-cpd-ccs
     cr_internal: true
     download_dependent_case: True
   - name: cde
@@ -83,6 +90,7 @@ cartridge_cr:
     olm_utils_name: cde
     inventory: cdeOperatorSetup
     search_string: ibm-cde
+    package_manifest: ibm-cde-operator
     cartridge_label: operators.coreos.com/ibm-cde-operator.ibm-common-services
     cr_cr: CdeProxyService
     cr_name: cdeproxyservice-cr
@@ -97,6 +105,7 @@ cartridge_cr:
     olm_utils_name: datagate
     inventory: datagateOperatorSetup
     search_string: ibm-datagate-prod
+    package_manifest: ibm-datagate-operator
     cartridge_label: operators.coreos.com/ibm-datagate-operator.ibm-common-services
     cr_cr: DatagateService
     cr_name: datagateservice-cr
@@ -107,11 +116,13 @@ cartridge_cr:
   - name: data-governor
     olm_utils_name: data_governor
     search_string: ibm-data-governor
+    package_manifest: ibm-data-governor-operator
     cr_internal: true
     download_dependent_case: True
   - name: datarefinery
     olm_utils_name: datarefinery
     search_string: ibm-datarefinery
+    package_manifest: ibm-cpd-datarefinery
     cr_internal: true
     download_dependent_case: True
   - name: datastage-ent-plus
@@ -119,6 +130,7 @@ cartridge_cr:
     olm_utils_name: datastage_ent_plus
     inventory: dsOperatorSetup
     search_string: ibm-datastage
+    package_manifest: ibm-cpd-datastage-operator
     cartridge_label: operators.coreos.com/ibm-cpd-datastage-operator.ibm-common-services
     cr_cr: DataStage
     cr_name: datastage
@@ -133,6 +145,7 @@ cartridge_cr:
     olm_utils_name: db2oltp
     inventory: db2oltpOperatorSetup
     search_string: ibm-db2oltp
+    package_manifest: ibm-db2oltp-cp4d-operator
     cartridge_label: operators.coreos.com/ibm-db2oltp-cp4d-operator.ibm-common-services
     cr_cr: Db2oltpService
     cr_name: db2oltp-cr
@@ -147,6 +160,7 @@ cartridge_cr:
     olm_utils_name: db2aaservice
     inventory: db2aaserviceOperatorSetup
     search_string: ibm-db2aaservice
+    package_manifest: ibm-db2aaservice-cp4d-operator
     cartridge_label: operators.coreos.com/ibm-db2aaservice-cp4d-operator.ibm-common-services
     cr_cr: Db2aaserviceService
     cr_name: db2aaservice-cr
@@ -162,6 +176,7 @@ cartridge_cr:
     olm_utils_name: db2u
     inventory: db2uOperatorSetup
     search_string: ibm-db2uoperator
+    package_manifest: db2u-operator
     cartridge_label: operators.coreos.com/db2u-operator.ibm-common-services
     cr_internal: False
     download_dependent_case: False
@@ -170,6 +185,7 @@ cartridge_cr:
     olm_utils_name: db2wh
     inventory: db2whOperatorSetup
     search_string: ibm-db2wh
+    package_manifest: ibm-db2wh-cp4d-operator
     cartridge_label: operators.coreos.com/ibm-db2wh-cp4d-operator.ibm-common-services
     cr_cr: Db2whService
     cr_name: db2wh-cr
@@ -184,6 +200,7 @@ cartridge_cr:
     olm_utils_name: dmc
     inventory: dmcOperatorSetup
     search_string: ibm-dmc
+    package_manifest: ibm-dmc-operator
     cartridge_label: operators.coreos.com/ibm-dmc-operator.ibm-common-services
     cr_cr: Dmcaddon
     cr_name: dmc-addon
@@ -199,6 +216,7 @@ cartridge_cr:
     olm_utils_name: dods
     inventory: dodsOperatorSetup
     search_string: ibm-dods
+    package_manifest: ibm-cpd-dods
     cartridge_label: operators.coreos.com/ibm-cpd-dods.ibm-common-services
     cr_cr: DODS
     cr_name: dods-cr
@@ -217,6 +235,7 @@ cartridge_cr:
     olm_utils_name: dp
     inventory: dpOperatorSetup
     search_string: ibm-dp
+    package_manifest: ibm-cpd-dp
     cartridge_label: operators.coreos.com/ibm-cpd-dp.ibm-common-services
     cr_cr: dp
     cr_name: dp-cr
@@ -231,6 +250,7 @@ cartridge_cr:
     olm_utils_name: dv
     inventory: dv
     search_string: ibm-dv-case
+    package_manifest: ibm-dv-operator
     cartridge_label: operators.coreos.com/ibm-dv-operator.ibm-common-services
     cr_cr: DvService
     cr_name: dv-service
@@ -248,6 +268,7 @@ cartridge_cr:
     olm_utils_name: hee
     inventory: hadoopSetup
     search_string: ibm-hadoop
+    package_manifest: ibm-cpd-hadoop
     cartridge_label: operators.coreos.com/ibm-cpd-hadoop.ibm-common-services
     cr_cr: Hadoop
     cr_name: hadoop-cr
@@ -261,6 +282,7 @@ cartridge_cr:
     operator_install_script: cp4d-install-iis-operator.yml
     inventory: iisOperatorSetup
     search_string: ibm-iis
+    package_manifest: ibm-cpd-iis
     cr_internal: true
     cr_cr: IIS
     cr_name: iis-cr
@@ -274,6 +296,7 @@ cartridge_cr:
     olm_utils_name: match360
     inventory: mdmOperator
     search_string: ibm-mdm
+    package_manifest: ibm-mdm
     cartridge_label: operators.coreos.com/ibm-mdm.ibm-common-services
     cr_cr: MasterDataManagement
     cr_name: mdm-cr
@@ -284,36 +307,43 @@ cartridge_cr:
   - name: model-train
     olm_utils_name: model_train
     search_string: ibm-model-train-operator
+    package_manifest: ibm-model-train-classic-operator
     cr_internal: true
     download_dependent_case: True
   - name: opencontent-auditwebhook
     olm_utils_name: opencontent_auditwebhook
     search_string: ibm-auditwebhook-operator
+    package_manifest: cp4d-audit-webhook-operator
     cr_internal: true
     download_dependent_case: True
   - name: opencontent-elasticsearch
     olm_utils_name: opencontent_elasticsearch
     search_string: ibm-elasticsearch-operator
+    package_manifest: ibm-elasticsearch-operator
     cr_internal: true
     download_dependent_case: True
   - name: opencontent-etcd
     olm_utils_name: opencontent_etcd
     search_string: ibm-etcd-operator
+    package_manifest: ibm-etcd-operator
     cr_internal: true
     download_dependent_case: True
   - name: opencontent-minio
     olm_utils_name: opencontent_minio
     search_string: ibm-minio-operator
+    package_manifest: ibm-minio-operator
     cr_internal: true
     download_dependent_case: True
   - name: opencontent-rabbitmq
     olm_utils_name: opencontent_rabbitmq
     search_string: ibm-rabbitmq-operator
+    package_manifest: ibm-rabbitmq-operator
     cr_internal: true
     download_dependent_case: True
   - name: opencontent-redis
     olm_utils_name: opencontent_redis
     search_string: ibm-cloud-databases-redis
+    package_manifest: ibm-cloud-databases-redis-operator
     cr_internal: true
     download_dependent_case: True
   - name: openpages
@@ -321,6 +351,7 @@ cartridge_cr:
     olm_utils_name: openpages
     inventory: operatorSetup
     search_string: ibm-openpages
+    package_manifest: ibm-cpd-openpages-operator
     cartridge_label: operators.coreos.com/ibm-cpd-openpages-operator.ibm-common-services
     cr_cr: OpenPagesService
     cr_name: openpages-cr
@@ -336,6 +367,7 @@ cartridge_cr:
     olm_utils_name: planning_analytics
     inventory: ibmPlanningAnalyticsOperatorSetup
     search_string: ibm-planning-analytics
+    package_manifest: ibm-planning-analytics-operator
     cartridge_label: operators.coreos.com/ibm-planning-analytics-operator.ibm-common-services
     cr_cr: PAService
     cr_name: ibm-planning-analytics-service
@@ -346,6 +378,7 @@ cartridge_cr:
   - name: postgresql
     olm_utils_name: postgresql
     search_string: ibm-cloud-native-postgresql
+    package_manifest: cloud-native-postgresql
     cr_internal: true
     download_dependent_case: True
   - name: productmaster
@@ -353,6 +386,7 @@ cartridge_cr:
     olm_utils_name: productmaster
     inventory: productmasterOperatorSetup
     search_string: ibm-productmaster
+    package_manifest: ibm-cpd-productmaster
     cartridge_label: operators.coreos.com/ibm-cpd-productmaster.ibm-common-services
     cr_cr: ProductMaster
     cr_name: productmaster-cr
@@ -365,6 +399,7 @@ cartridge_cr:
     cartridge_label: operators.coreos.com/ibm-cpd-rstudio.ibm-common-services
     inventory: rstudioSetup
     search_string: ibm-rstudio
+    package_manifest: ibm-cpd-rstudio
     cr_cr: RStudioAddon
     cr_name: rstudio-cr
     cr_status_attribute: rstudioStatus
@@ -379,6 +414,7 @@ cartridge_cr:
     olm_utils_name: spss
     inventory: spssSetup
     search_string: ibm-spss
+    package_manifest: ibm-cpd-spss
     cartridge_label: operators.coreos.com/ibm-cpd-spss.ibm-common-services
     cr_cr: Spss
     cr_name: spss-sample
@@ -396,6 +432,7 @@ cartridge_cr:
     olm_utils_name: voice_gateway
     inventory: voiceGatewayOperatorSetup
     search_string: ibm-voice-gateway
+    package_manifest: ibm-voice-gateway-operator
     cartridge_label: operators.coreos.com/ibm-voice-gateway-operator.ibm-common-services
     cr_cr: VoiceGateway
     cr_name: voicegateway-cr
@@ -410,6 +447,7 @@ cartridge_cr:
     cr_preprocessing_script: cp4d-prep-watson-assistant.yml
     inventory: assistantOperator
     search_string: ibm-watson-assistant
+    package_manifest: ibm-watson-assistant-operator
     cartridge_label: operators.coreos.com/ibm-watson-assistant-operator.ibm-common-services
     cr_cr: WatsonAssistant
     cr_name: wa
@@ -433,6 +471,7 @@ cartridge_cr:
     olm_utils_name: watson_discovery
     inventory: discoveryOperators
     search_string: ibm-watson-discovery
+    package_manifest: ibm-watson-discovery-operator
     cartridge_label: operators.coreos.com/ibm-watson-discovery-operator.ibm-common-services
     cr_cr: WatsonDiscovery
     cr_name: wd
@@ -451,6 +490,7 @@ cartridge_cr:
   - name: watson-gateway
     olm_utils_name: watson_gateway
     search_string: ibm-watson-gateway-operator
+    package_manifest: ibm-watson-gateway-operator
     cr_internal: true
     download_dependent_case: True
   - name: watson-ks
@@ -459,6 +499,7 @@ cartridge_cr:
     cartridge_label: operators.coreos.com/ibm-watson-ks-operator.ibm-common-services
     inventory: wksOperatorSetup
     search_string: ibm-watson-ks
+    package_manifest: ibm-watson-ks-operator
     cr_cr: KnowledgeStudio
     cr_name: wks
     cr_status_attribute: .conditions[?(@.type=="Deployed")].status
@@ -470,6 +511,7 @@ cartridge_cr:
     olm_utils_name: openscale
     inventory: ibmWatsonOpenscaleOperatorSetup
     search_string: ibm-watson-openscale
+    package_manifest: ibm-cpd-wos
     cartridge_label: operators.coreos.com/ibm-cpd-wos.ibm-common-services
     cr_cr: WOService
     cr_name: aiopenscale
@@ -482,6 +524,7 @@ cartridge_cr:
     olm_utils_name: watson_speech
     inventory: speechOperatorSetup
     search_string: ibm-watson-speech
+    package_manifest: ibm-watson-speech-operator
     cartridge_label: operators.coreos.com/ibm-watson-speech-operator.ibm-common-services
     cr_cr: WatsonSpeech
     cr_name: speech-prod-cr
@@ -499,6 +542,7 @@ cartridge_cr:
     olm_utils_name: wkc
     inventory: wkcOperatorSetup
     search_string: ibm-wkc
+    package_manifest: ibm-cpd-wkc
     cartridge_label: operators.coreos.com/ibm-cpd-wkc.ibm-common-services
     cr_cr: WKC
     cr_name: wkc-cr
@@ -517,6 +561,7 @@ cartridge_cr:
     olm_utils_name: wml
     inventory: wmlOperatorSetup
     search_string: ibm-wml-cpd
+    package_manifest: ibm-cpd-wml-operator
     cartridge_label: operators.coreos.com/ibm-cpd-wml-operator.ibm-common-services
     cr_cr: WMLBase
     cr_name: wml-cr
@@ -531,6 +576,7 @@ cartridge_cr:
     olm_utils_name: wml_accelerator
     inventory: wmla_operator_deploy
     search_string: ibm-wml-accelerator
+    package_manifest: ibm-cpd-wml-accelerator-operator
     cartridge_label: operators.coreos.com/ibm-cpd-wml-accelerator-operator.ibm-common-services
     cr_cr: Wmla-add-on
     cr_name: wmla
@@ -545,6 +591,7 @@ cartridge_cr:
     olm_utils_name: ws
     inventory: wslSetup
     search_string: ibm-wsl
+    package_manifest: ibm-cpd-wsl
     cartridge_label: operators.coreos.com/ibm-cpd-wsl.ibm-common-services
     cr_cr: WS
     cr_name: ws-cr
@@ -560,5 +607,6 @@ cartridge_cr:
     olm_utils_name: ws_runtimes
     inventory: runtimesOperatorSetup
     search_string: ibm-wsl-runtimes
+    package_manifest: ibm-cpd-ws-runtimes
     cr_internal: true
     download_dependent_case: True

--- a/doc/src/pages/advanced/gitops/index.mdx
+++ b/doc/src/pages/advanced/gitops/index.mdx
@@ -26,32 +26,21 @@ In the Cloud Pak Deployer, we have chosen to reference the CASE versions in the 
 cp4d:
 - project: zen-40
   openshift_cluster_name: {{ env_id }}
-  cp4d_version: 4.0
+  cp4d_version: 4.0.9
   openshift_storage_name: ocs-storage
   use_case_files: True
   olm_utils: False
   cartridges:
   - name: cpfs
-    case_version: 1.6.0
   - name: cpd_platform
-    subscription_channel: v2.0
-    case_version: 2.0.5
   - name: ws
-    version: 4.0.2
-    subscription_channel: v2.0
-    case_version: 2.0.2
     state: installed
   - name: wml
-    version: 4.0.2
-    subscription_channel: v1.1
-    case_version: 4.0.3
     size: small
     state: installed
 ```
 
-In the above example Watson Studio (`ws`) version `4.0.2` will be installed by the operator with version `2.0.2`. Cloud Pak for Data and the other Cloud Paks use the `cloudctl case` tool to define the package of images and manifests for `CatalogSource` and operators. Version `2.0.2` defines the Watson Studio operator which will be installed when the subscription is being created.
-
-If Cloud Pak for Data has been configured with a private registry in the deployer config, the deployer will mirror images from the IBM entitled registry to the private registry. In the above configuration, no private registry has been specified but `use_case_files` has been set to `True`, which means that the deployer will automatically download and use the CASE files to create the catalog sources.
+If Cloud Pak for Data has been configured with a private registry in the deployer config, the deployer will mirror images from the IBM entitled registry to the private registry. In the above configuration, no private registry has been specified. The deployer will automatically download and use the CASE files to create the catalog sources.
 
 ## Change process using git-flow
 With the initial status in place, the continuous adoption process may commence, using the principles of git-flow.

--- a/doc/src/pages/cpd-design/components/cloud-pak/index.mdx
+++ b/doc/src/pages/cpd-design/components/cloud-pak/index.mdx
@@ -11,20 +11,16 @@ An example Cloud Pak for Data object is below:
 cp4d:
 - project: zen-40
   openshift_cluster_name: sample
-  cp4d_version: 4.0
+  cp4d_version: 4.0.9
   use_case_files: True
   olm_utils: False
   openshift_storage_name: ocs-storage
   
   cartridges:
   - name: cpfs
-    case_version: 1.6.0
   - name: cpd_platform
-    subscription_channel: v2.0
-    version: 4.0.1
-    case_version: 2.0.4
 ```
 
-The above Cloud Pak for Data object will install the control plane into project `zen-40` of OpenShift cluster `sample`. OpenShift Data Foundation (fka OCS) is used as the storage type for the control plane and cartridges.
+The above Cloud Pak for Data object will install the control plane version 4.0.9 into project `zen-40` of OpenShift cluster `sample`. OpenShift Data Foundation (fka OCS) is used as the storage type for the control plane and cartridges.
 
 For more information about defining the Cloud Paks, refer to [Cloud Paks](/cpd-design/objects/cloud-paks)

--- a/doc/src/pages/cpd-design/components/cp4d-cartridges/index.mdx
+++ b/doc/src/pages/cpd-design/components/cp4d-cartridges/index.mdx
@@ -11,23 +11,17 @@ An example Cloud Pak for Data object with cartridges is below:
 cp4d:
 - project: zen-40
   openshift_cluster_name: sample
-  cp4d_version: 4.0
+  cp4d_version: 4.0.9
   use_case_files: True
   olm_utils: False
   openshift_storage_name: ocs-storage
   
   cartridges:
   - name: cpfs
-    case_version: 1.6.0
+    
   - name: cpd_platform
-    subscription_channel: v2.0
-    version: 4.0.1
-    case_version: 2.0.4
 
   - name: db2oltp
-    version: 4.0.8
-    subscription_channel: v1.0
-    case_version: 4.0.8
     size: small
     instances:
     - name: db2-instance
@@ -38,31 +32,19 @@ cp4d:
     state: installed
 
   - name: wkc
-    version: 4.0.6
-    subscription_channel: v1.0
-    case_version: 4.0.6
     size: small
     state: removed
 
   - name: wml
-    version: 4.0.6
-    subscription_channel: v1.1
-    case_version: 4.0.7
     size: small
     state: installed
 
   - name: wml-accelerator
-    version: 2.3.6
-    subscription_channel: v1.0
-    case_version: 2.3.6
     replicas: 1
     size: small
     state: removed
 
   - name: ws
-    version: 4.0.6
-    subscription_channel: v2.0
-    case_version: 2.0.6
     state: installed
 ```
 

--- a/doc/src/pages/cpd-design/components/cp4d-instances/index.mdx
+++ b/doc/src/pages/cpd-design/components/cp4d-instances/index.mdx
@@ -12,9 +12,6 @@ cp4d:
   openshift_cluster_name: {{ env_id }}
 ...
   - name: cognos_analytics
-    version: 4.0.6
-    subscription_channel: v4.0
-    case_version: 4.0.8
     size: small
     instances:
     - name: ca-instance
@@ -22,9 +19,6 @@ cp4d:
     state: installed
 
   - name: db2
-    version: 4.0.8
-    subscription_channel: v1.0
-    case_version: 4.0.8
     size: small
     instances:
     - name: ca-metastore

--- a/doc/src/pages/cpd-design/components/private-registry/index.mdx
+++ b/doc/src/pages/cpd-design/components/private-registry/index.mdx
@@ -17,9 +17,9 @@ If you want to use a private registry when running the deployer for a ROKS clust
 
 ```
 image_registry:
-- name: cpd405
+- name: cpd409
   registry_host_name: de.icr.io
-  registry_namespace: cpd405
+  registry_namespace: cpd409
 ```
 
 The registry host name must end with `icr.io` and the registry namespace is mandatory. No other properties are needed; the deployer will retrieve them from IBM Cloud.
@@ -27,7 +27,7 @@ The registry host name must end with `icr.io` and the registry namespace is mand
 If you have already created the ICR namespace, create a vault secret for the image registry credentials:
 ```
 ./cp-deploy.sh vault set \
-  -vs image-registry-cpd405
+  -vs image-registry-cpd409
   -vsv "admin:very_s3cret"
 ```
 
@@ -36,12 +36,12 @@ An example of configuring the private registry for a `cp4d` object is below:
 cp4d:
 - project: zen-40
   openshift_cluster_name: {{ env_id }}
-  cp4d_version: 4.0
+  cp4d_version: 4.0.9
   openshift_storage_name: ocs-storage
-  image_registry_name: cpd405
+  image_registry_name: cpd409
 ```
 
-The Cloud Pak for Data installation refers to the `cpd405` `image_registry` object.
+The Cloud Pak for Data installation refers to the `cpd9` `image_registry` object.
 
 If the `ibm_cp_entitlement_key` secret is in the vault at the time of running the deployer, the required images will be mirrored from the entitled registry to the private registry. If all images are already available in the private registry, just specify the `--skip-mirror-images` flag when you run the deployer.
 
@@ -52,23 +52,23 @@ Configure an [image_registry](/cpd-design/objects/cloud-paks#image_registry) obj
 Example:
 ```
 image_registry:
-- name: cpd405
+- name: cpd409
   registry_host_name: registry.coc.uk.ibm.com
   registry_port: 15000
-  registry_trusted_ca_secret: cpd405-ca-bundle
+  registry_trusted_ca_secret: cpd409-ca-bundle
 ```
 
 To create the vault secret for the image registry credentials:
 ```
 ./cp-deploy.sh vault set \
-  -vs image-registry-cpd405
+  -vs image-registry-cpd409
   -vsv "admin:very_s3cret"
 ```
 
 To create the vault secret for the CA bundle:
 ```
 ./cp-deploy.sh vault set \
-  -vs cpd405-ca-bundle
+  -vs cpd409-ca-bundle
   -vsf /tmp/ca.crt
 ```
 
@@ -88,12 +88,12 @@ An example of configuring the private registry for a `cp4d` object is below:
 cp4d:
 - project: zen-40
   openshift_cluster_name: {{ env_id }}
-  cp4d_version: 4.0
+  cp4d_version: 4.0.9
   openshift_storage_name: ocs-storage
-  image_registry_name: cpd405
+  image_registry_name: cpd409
 ```
 
-The Cloud Pak for Data installation refers to the `cpd405` `image_registry` object.
+The Cloud Pak for Data installation refers to the `cpd409` `image_registry` object.
 
 If the `ibm_cp_entitlement_key` secret is in the vault at the time of running the deployer, the required images will be mirrored from the entitled registry to the private registry. If all images are already available in the private registry, just specify the `--skip-mirror-images` flag when you run the deployer.
 

--- a/doc/src/pages/cpd-design/objects/cartridges.mdx
+++ b/doc/src/pages/cpd-design/objects/cartridges.mdx
@@ -8,15 +8,24 @@ tabs: ['Objects', 'Vault', 'Infrastructure', 'OpenShift', 'Cloud Paks', 'Cartrid
 ## Cloud Pak for Data cartridges
 
 ### `cp4d.cartridges`
-This is a list of cartridges that will be installed in the Cloud Pak for Data instance. Every cartridge will have a number of mandatory properties such as name and subscription channel. Then, some cartridges may require additional information to correctly install or to create an instance for the cartridge. Below you will find a list of all tested cartridges and their specifics.
+This is a list of cartridges that will be installed in the Cloud Pak for Data instance. Every cartridge is identified by its name.
+
+By default, the `case_version`, `subscription_channel` and `version` properties are retrieved using **olm-utils** using the `cp4d_version` property at the `cp4d` level. If you wish you can override the inferred values by specifying them at the cartridge level but this is typically not necessary.
+
+<InlineNotification kind="warning">
+Use with care: If you decide to override the inferred values, this may have unexpected consequences as there are dependencies between some cartridges. For example: both Watson Studio (ws) and Watson Knowledge Catalog (wkc) use the Common Core Services (ccs). If you choose to override the version for ws, the ccs version installed may not be compatible with wkc.
+</InlineNotification>
+
+
+Some cartridges may require additional information to correctly install or to create an instance for the cartridge. Below you will find a list of all tested cartridges and their specifics.
 
 #### Properties for all cartridges
 | Property | Description                                                          | Mandatory | Allowed values |
 | -------- | -------------------------------------------------------------------- | --------- | -------------- |
 | name     | Name of the cartridge                                         | Yes | |
-| subscription_channel | Channel of the subscription                   | Yes for CP4D cartridges | |
-| version  | Version of the custom resource to be installed. If not specified, the latest version of the custom resource for the specified channel will be installed | No | |
-| case_version | Version of cartridge operator. If not specified and CASE files are used, the latest case file found for the cartridge will be used to install the catalog source | No | |
+| subscription_channel | Channel of the subscription. If specified this will override the value retrieved by **olm-utils** based on the `cp4d_version` | No | |
+| version  | Version of the custom resource to be installed. If specified this will override the value retrieved by **olm-utils** based on the `cp4d_version` | No | |
+| case_version | Version of cartridge operator. If specified this will override the value retrieved by **olm-utils** based on the `cp4d_version` | No | |
 | dependencies | A List of cartridges (which should also be listed in the cp4d.cartridges) that need to be deployed prior to deploying the current cartridge | No | |
 | state     | Whether the cartridge must be `installed` or `removed`. If not specified, the cartridge will be installed | No | installed, removed |
 
@@ -28,11 +37,9 @@ This cartridge is mandatory for every Cloud Pak for Data instance.
 #### Additional properties for cartridge `cpfs`
 | Property | Description                                                          | Mandatory | Allowed values |
 | -------- | -------------------------------------------------------------------- | --------- | -------------- |
-| subscription_channel | Channel of the subscription                              | Yes for CP4D cartridges | |
+| subscription_channel | Channel of the subscription. If specified this will override the value retrieved by **olm-utils** based on the `cp4d_version` | No | |
 
 ### Cartridge `cpd_platform` or `lite`
 Defines the Cloud Pak for Data platform operator (fka "lite") which installs the base services needed to operate Cloud Pak for Data, such as the Zen metastore, Zen watchdog and the user interface. 
 
 This cartridge is mandatory for every Cloud Pak for Data instance.
-
-### Cartridge `analyticsengine`

--- a/doc/src/pages/cpd-design/objects/cloud-paks.mdx
+++ b/doc/src/pages/cpd-design/objects/cloud-paks.mdx
@@ -14,7 +14,7 @@ Defines the Cloud Pak for Data instances to be configured on the OpenShift clust
 cp4d:
 - project: zen-40
   openshift_cluster_name: sample
-  cp4d_version: 4.0.7
+  cp4d_version: 4.0.9
   use_case_files: False
   olm_utils: False
   change_node_settings: True
@@ -24,11 +24,7 @@ cp4d:
   
   cartridges:
   - name: cpfs
-    case_version: 1.6.0
   - name: cpd_platform
-    subscription_channel: v2.0
-    version: 4.0.1
-    case_version: 2.0.4
 ```
 
 #### Properties
@@ -36,14 +32,14 @@ cp4d:
 | -------- | -------------------------------------------------------------------- | --------- | -------------- |
 | project  | Name of the OpenShift project of the Cloud Pak for Data instance     | Yes       |  |
 | openshift_cluster_name | Name of the OpenShift cluster                  | Yes       | Existing `openshift` cluster |
-| cp4d_version | Cloud Pak for Data version to use when `olm_utils` is `True`     | Yes if `olm_utils` is `True` | 4.x.x |
+| cp4d_version | Cloud Pak for Data version to install, this will determine the version for all cartridges that do not specify a version | Yes | 4.x.x |
 | use_case_files | This property indicates whether or not the case files will be used to install the catalog sources in case of an online install from the entitled registry. If `true`, operator case files are downloaded from the case repository to define the catalog sources. If a private registry has been specified (property `image_registry_name`), it is assumed that case file are used to install the catalog sources.                | No       | True, False (default) |
 | olm_utils | If set to `True` the deployer will use the **OLM utils** to install catalog sources, subscriptions and CRs | No | False (default), True |
 | change_node_settings | Controls whether the node settings using the machine configs will be applied onto the OpenShift cluster. | No | True, False |
 | accept_licenses | Set to 'True' to accept Cloud Pak licenses. Alternatively the `--accept-all-licenses` can be used for the `cp-deploy.sh` command | Yes | True, False |
 | image_registry_name | When using private registry, specify name of `image_registry` | No       |  |
 | openshift_storage_name | References an `openshift_storage` element in the OpenShift cluster that was defined for this Cloud Pak for Data instance. The name must exist under `openshift.[openshift_cluster_name].openshift_storage. | No, inferred | |
-| cartridges | List of cartridges to install for this Cloud Pak for Data instance. See [Cloud Pak for Data cartridges](/cpd-design/objects/cartridges#cp4d.cartridges) for more details | Yes | |
+| cartridges | List of cartridges to install for this Cloud Pak for Data instance. See [Cloud Pak for Data cartridges](/cpd-design/objects/cartridges) for more details | Yes | |
 
 ### `image_registry`
 Defines a private registry that will be used for pulling the Cloud Pak container images from. Additionally, if the Cloud Pak entitlement key was specified at run time of the deployer, the images defined by the case files will be mirrored to this private registry.

--- a/docker-scripts/env-download-prepare.sh
+++ b/docker-scripts/env-download-prepare.sh
@@ -6,6 +6,9 @@ echo "Starting download preparation script..."
 echo ""
 cd ${SCRIPT_DIR}/..
 
+# Ensure /tmp/work exists
+mkdir -p /tmp/work
+
 # Set Ansible config file to use
 ANSIBLE_CONFIG_FILE=$PWD/playbooks/ansible-download.cfg
 if $ANSIBLE_STANDARD_OUTPUT || [ "$ANSIBLE_VERBOSE" != "" ];then

--- a/docker-scripts/run_automation.sh
+++ b/docker-scripts/run_automation.sh
@@ -26,6 +26,9 @@ echo "Starting Automation script..."
 echo ""
 cd ${SCRIPT_DIR}/..
 
+# Ensure /tmp/work exists
+mkdir -p /tmp/work
+
 # Check that subcommand is valid
 export SUBCOMMAND=${SUBCOMMAND,,}
 export ACTION=${ACTION,,}

--- a/sample-configurations/roks-ocs-cp4d/config/cp4d-409.yaml
+++ b/sample-configurations/roks-ocs-cp4d/config/cp4d-409.yaml
@@ -45,7 +45,7 @@ cp4d:
     state: removed
 
   - name: datastage-ent-plus
-    state: installed
+    state: removed
 
   - name: db2
     size: small
@@ -146,7 +146,7 @@ cp4d:
 
   - name: wml
     size: small
-    state: removed
+    state: installed
 
   - name: wml-accelerator
     replicas: 1
@@ -154,7 +154,7 @@ cp4d:
     state: removed
 
   - name: wsl
-    state: removed
+    state: installed
 
 #
 # Cartridge case dependencies

--- a/sample-configurations/roks-ocs-cp4d/config/cp4d-409.yaml
+++ b/sample-configurations/roks-ocs-cp4d/config/cp4d-409.yaml
@@ -3,7 +3,7 @@ cp4d:
 
 - project: zen-40
   openshift_cluster_name: "{{ env_id }}"
-  cp4d_version: 4.0
+  cp4d_version: 4.0.9
   use_case_files: True
   accept_licenses: False
   cartridges:
@@ -11,14 +11,8 @@ cp4d:
     license_service:
       state: disabled
       threads_per_core: 2
-    case_version: 1.14.0
   - name: lite
-    subscription_channel: v2.0
-    case_version: 2.0.13
   - name: scheduler 
-    version: 1.3.5
-    subscription_channel: v1.3
-    case_version: 1.3.5
     state: removed
     
 #
@@ -31,22 +25,13 @@ cp4d:
 #
 
   - name: analyticsengine 
-    version: 4.0.9
-    subscription_channel: stable-v1
-    case_version: 4.0.9
     size: small 
     state: removed
 
   - name: bigsql
-    version: 7.2.8
-    subscription_channel: v7.2
-    case_version: 7.2.8
     state: removed
 
   - name: ca
-    version: 4.0.8
-    subscription_channel: v4.0
-    case_version: 4.0.10
     size: small
     instances:
     - name: ca-instance
@@ -54,27 +39,15 @@ cp4d:
     state: removed
 
   - name: cde
-    version: 4.0.9
-    subscription_channel: v1.0
-    case_version: 2.0.9
     state: removed
 
   - name: datagate
-    version: 2.0.8
-    subscription_channel: v2.0
-    case_version: 4.0.8
     state: removed
 
   - name: datastage-ent-plus
-    version: 4.0.9
-    subscription_channel: v1.0
-    case_version: 4.0.10
     state: installed
 
   - name: db2
-    version: 4.0.10
-    subscription_channel: v1.0
-    case_version: 4.0.10
     size: small
     instances:
     - name: ca-metastore
@@ -85,27 +58,15 @@ cp4d:
     state: removed
 
   - name: db2u
-    version: 4.0.10
-    subscription_channel: v1.1
-    case_version: 4.0.10
     state: removed
 
   - name: db2wh
-    version: 4.0.10
-    subscription_channel: v1.0
-    case_version: 4.0.10
     state: removed
 
   - name: dmc
-    version: 4.0.8
-    subscription_channel: v1.0
-    case_version: 4.0.8
     state: removed
 
   - name: dods
-    version: 4.0.9
-    subscription_channel: v4.0
-    case_version: 4.0.9
     size: small
     dependencies:
     - name: wsl
@@ -113,16 +74,10 @@ cp4d:
     state: removed
 
   - name: dp
-    version: 4.0.9
-    subscription_channel: v1.0
-    case_version: 4.0.9
     size: small
     state: removed
 
   - name: dv
-    version: 1.7.8
-    subscription_channel: v1.7
-    case_version: 1.7.8
     size: small 
     dependencies:
     - name: db2u
@@ -131,140 +86,89 @@ cp4d:
     state: removed
 
   - name: hadoop
-    version: 4.0.9
     size: small
-    subscription_channel: v1.0
-    case_version: 4.0.10
     dependencies:
     - name: wsl
     state: removed
 
   - name: mdm
-    version: 1.1.278
-    subscription_channel: v1.1
-    case_version: 1.0.209
     size: small
     wkc_enabled: true
     state: removed
 
   - name: openpages
-    version: 8.204.5
-    subscription_channel: v1.0
-    case_version: 2.1.5+20220414.030441.82040426
     state: removed
 
+  # For Planning Analytics, the case version is needed due to defect in olm utils
   - name: planning-analytics
-    version: 4.0.9
-    subscription_channel: v4.0
     case_version: 4.0.90573
     state: removed
 
   - name: rstudio
-    version: 4.0.9
-    subscription_channel: v1.0
-    case_version: 1.0.9
     size: small
     dependencies:
     - name: wsl
     state: removed
 
   - name: spss
-    version: 4.0.9
-    subscription_channel: v1.0
-    case_version: 1.0.9
     dependencies:
     - name: wsl
     state: removed
 
   - name: voice-gateway
-    version: 1.0.8
-    subscription_channel: v1.0
-    case_version: 1.0.6
     replicas: 1
     state: removed
 
   - name: watson-assistant
-    version: 4.0.8
-    subscription_channel: v4.0
-    case_version: 4.0.8
     size: small
     state: removed
 
   - name: watson-discovery
-    version: 4.0.9
-    subscription_channel: v4.0
-    case_version: 4.0.9
     state: removed
 
+  # For Watson Knowledge Studio, the case version is needed due to defect in olm utils
   - name: watson-ks
-    version: 4.0.9
-    subscription_channel: v4.0
-    case_version: 4.0.9
     size: small
     state: removed
 
   - name: watson-openscale
-    version: 4.0.9
-    subscription_channel: v1.5
-    case_version: 2.5.4
     size: small
     state: removed
 
   - name: watson-speech
-    version: 4.0.9
-    subscription_channel: v4.0
-    case_version: 4.0.10
     stt_size: xsmall
     tts_size: xsmall
     state: removed
 
   - name: wkc
-    version: 4.0.9
-    subscription_channel: v1.0
-    case_version: 4.0.9
     size: small
     state: removed
 
   - name: wml
-    version: 4.0.9
-    subscription_channel: v1.1
-    case_version: 4.0.10
     size: small
     state: removed
 
   - name: wml-accelerator
-    version: 2.3.9
-    subscription_channel: v1.0
-    case_version: 2.3.9
     replicas: 1
     size: small
     state: removed
 
   - name: wsl
-    version: 4.0.9
-    subscription_channel: v2.0
-    case_version: 2.0.9
     state: removed
 
 #
 # Cartridge case dependencies
 #
   - name: ccs
-    case_version: 1.0.9
 
   - name: datarefinery
-    case_version: 1.0.9
     
   - name: wsl-runtimes
-    case_version: 1.0.9
 
 #
 # Cartridges where extra work is needed (will not install automatically)
 # 
   # Product Master requires set up of the Db2 instance secret before install
   - name: productmaster
-    version: 1.0.4
-    subscription_channel: v1.0
     size: small  
-    case_version: 1.0.4+20220511.175530.3
     state: removed

--- a/sample-configurations/sample-dynamic/config-samples/cp4d-407-private-registry.yaml
+++ b/sample-configurations/sample-dynamic/config-samples/cp4d-407-private-registry.yaml
@@ -9,7 +9,8 @@ cp4d:
 
 - project: zen-40
   openshift_cluster_name: "{{ env_id }}"
-  cp4d_version: 4.0
+  cp4d_version: 4.0.7
+  olm_utils: False
   image_registry_name: cpd407
   use_case_files: True
   accept_licenses: False

--- a/sample-configurations/sample-dynamic/config-samples/cp4d-408.yaml
+++ b/sample-configurations/sample-dynamic/config-samples/cp4d-408.yaml
@@ -3,7 +3,8 @@ cp4d:
 
 - project: zen-40
   openshift_cluster_name: "{{ env_id }}"
-  cp4d_version: 4.0
+  cp4d_version: 4.0.8
+  olm_utils: False
   use_case_files: True
   accept_licenses: False
   cartridges:

--- a/sample-configurations/sample-dynamic/config-samples/cp4d-409-specific-versions.yaml
+++ b/sample-configurations/sample-dynamic/config-samples/cp4d-409-specific-versions.yaml
@@ -3,7 +3,7 @@ cp4d:
 
 - project: zen-40
   openshift_cluster_name: "{{ env_id }}"
-  cp4d_version: 4.0.7
+  cp4d_version: 4.0.9
   olm_utils: False
   use_case_files: True
   accept_licenses: False
@@ -12,16 +12,16 @@ cp4d:
     license_service:
       state: disabled
       threads_per_core: 2
-    case_version: 1.12.3
+    case_version: 1.14.0
   - name: lite
     subscription_channel: v2.0
-    case_version: 2.0.12
+    case_version: 2.0.13
   - name: scheduler 
-    version: 1.3.3
+    version: 1.3.5
     subscription_channel: v1.3
-    case_version: 1.3.3
+    case_version: 1.3.5
     state: removed
-
+    
 #
 # All tested cartridges. To install, change the "state" property to "installed". To uninstall, change the state
 # to "removed" or comment out the entire cartridge. Make sure that the "-" and properties are aligned with the lite
@@ -32,22 +32,22 @@ cp4d:
 #
 
   - name: analyticsengine 
-    version: 4.0.7
+    version: 4.0.9
     subscription_channel: stable-v1
-    case_version: 4.0.7
+    case_version: 4.0.9
     size: small 
     state: removed
 
   - name: bigsql
-    version: 7.2.7
+    version: 7.2.8
     subscription_channel: v7.2
-    case_version: 7.2.7
+    case_version: 7.2.8
     state: removed
 
   - name: ca
-    version: 4.0.7
+    version: 4.0.8
     subscription_channel: v4.0
-    case_version: 4.0.9
+    case_version: 4.0.10
     size: small
     instances:
     - name: ca-instance
@@ -55,27 +55,27 @@ cp4d:
     state: removed
 
   - name: cde
-    version: 4.0.7
+    version: 4.0.9
     subscription_channel: v1.0
-    case_version: 2.0.7
+    case_version: 2.0.9
     state: removed
 
   - name: datagate
-    version: 2.0.7
+    version: 2.0.8
     subscription_channel: v2.0
-    case_version: 4.0.7
-    state: removed
-
-  - name: datastage-ent-plus
-    version: 4.0.7
-    subscription_channel: v1.0
     case_version: 4.0.8
     state: removed
 
-  - name: db2
+  - name: datastage-ent-plus
     version: 4.0.9
     subscription_channel: v1.0
-    case_version: 4.0.9
+    case_version: 4.0.10
+    state: removed
+
+  - name: db2
+    version: 4.0.10
+    subscription_channel: v1.0
+    case_version: 4.0.10
     size: small
     instances:
     - name: ca-metastore
@@ -86,27 +86,27 @@ cp4d:
     state: removed
 
   - name: db2u
-    version: 4.0.9
+    version: 4.0.10
     subscription_channel: v1.1
-    case_version: 4.0.9
+    case_version: 4.0.10
     state: removed
 
   - name: db2wh
-    version: 4.0.9
+    version: 4.0.10
     subscription_channel: v1.0
-    case_version: 4.0.9
+    case_version: 4.0.10
     state: removed
 
   - name: dmc
-    version: 4.0.7
+    version: 4.0.8
     subscription_channel: v1.0
-    case_version: 4.0.7
+    case_version: 4.0.8
     state: removed
 
   - name: dods
-    version: 4.0.7
+    version: 4.0.9
     subscription_channel: v4.0
-    case_version: 4.0.7
+    case_version: 4.0.9
     size: small
     dependencies:
     - name: wsl
@@ -114,16 +114,16 @@ cp4d:
     state: removed
 
   - name: dp
-    version: 4.0.7
+    version: 4.0.9
     subscription_channel: v1.0
-    case_version: 4.0.7
+    case_version: 4.0.9
     size: small
     state: removed
 
   - name: dv
-    version: 1.7.7
+    version: 1.7.8
     subscription_channel: v1.7
-    case_version: 1.7.7
+    case_version: 1.7.8
     size: small 
     dependencies:
     - name: db2u
@@ -132,140 +132,140 @@ cp4d:
     state: removed
 
   - name: hadoop
-    version: 4.0.7
+    version: 4.0.9
     size: small
     subscription_channel: v1.0
-    case_version: 4.0.8
+    case_version: 4.0.10
     dependencies:
     - name: wsl
     state: removed
 
   - name: mdm
-    version: 1.1.215
+    version: 1.1.278
     subscription_channel: v1.1
-    case_version: 1.0.191
+    case_version: 1.0.209
     size: small
     wkc_enabled: true
     state: removed
 
   - name: openpages
-    version: 8.204.4
+    version: 8.204.5
     subscription_channel: v1.0
-    case_version: 2.1.4+20220304.003659.82040314
+    case_version: 2.1.5+20220414.030441.82040426
     state: removed
 
   - name: planning-analytics
-    version: 4.0.7
+    version: 4.0.9
     subscription_channel: v4.0
-    case_version: 4.0.70508
+    case_version: 4.0.90573
     state: removed
 
   - name: rstudio
-    version: 4.0.7
+    version: 4.0.9
     subscription_channel: v1.0
-    case_version: 1.0.7
+    case_version: 1.0.9
     size: small
     dependencies:
     - name: wsl
     state: removed
 
   - name: spss
-    version: 4.0.7
+    version: 4.0.9
     subscription_channel: v1.0
-    case_version: 1.0.7
+    case_version: 1.0.9
     dependencies:
     - name: wsl
     state: removed
 
   - name: voice-gateway
-    version: 1.0.7
+    version: 1.0.8
     subscription_channel: v1.0
-    case_version: 1.0.5
+    case_version: 1.0.6
     replicas: 1
     state: removed
 
   - name: watson-assistant
-    version: 4.0.7
+    version: 4.0.8
     subscription_channel: v4.0
-    case_version: 4.0.7
+    case_version: 4.0.8
     size: small
     state: removed
 
   - name: watson-discovery
-    version: 4.0.7
+    version: 4.0.9
     subscription_channel: v4.0
-    case_version: 4.0.7
+    case_version: 4.0.9
     state: removed
 
   - name: watson-ks
-    version: 4.0.7
+    version: 4.0.9
     subscription_channel: v4.0
-    case_version: 4.0.7
+    case_version: 4.0.9
     size: small
     state: removed
 
   - name: watson-openscale
-    version: 4.0.7
+    version: 4.0.9
     subscription_channel: v1.5
-    case_version: 2.5.2
+    case_version: 2.5.4
     size: small
     state: removed
 
   - name: watson-speech
-    version: 4.0.7
+    version: 4.0.9
     subscription_channel: v4.0
-    case_version: 4.0.8
+    case_version: 4.0.10
     stt_size: xsmall
     tts_size: xsmall
     state: removed
 
   - name: wkc
-    version: 4.0.7
+    version: 4.0.9
     subscription_channel: v1.0
-    case_version: 4.0.7
+    case_version: 4.0.9
     size: small
     state: removed
 
   - name: wml
-    version: 4.0.7
+    version: 4.0.9
     subscription_channel: v1.1
-    case_version: 4.0.8
+    case_version: 4.0.10
     size: small
     state: installed
 
   - name: wml-accelerator
-    version: 2.3.7
+    version: 2.3.9
     subscription_channel: v1.0
-    case_version: 2.3.7
+    case_version: 2.3.9
     replicas: 1
     size: small
     state: removed
 
   - name: wsl
-    version: 4.0.7
+    version: 4.0.9
     subscription_channel: v2.0
-    case_version: 2.0.7
+    case_version: 2.0.9
     state: installed
 
 #
 # Cartridge case dependencies
 #
   - name: ccs
-    case_version: 1.0.7
+    case_version: 1.0.9
 
   - name: datarefinery
-    case_version: 1.0.7
+    case_version: 1.0.9
     
   - name: wsl-runtimes
-    case_version: 1.0.7
+    case_version: 1.0.9
 
 #
 # Cartridges where extra work is needed (will not install automatically)
 # 
   # Product Master requires set up of the Db2 instance secret before install
   - name: productmaster
-    version: 1.0.3
+    version: 1.0.4
     subscription_channel: v1.0
     size: small  
-    case_version: 1.0.3
+    case_version: 1.0.4+20220511.175530.3
     state: removed

--- a/sample-configurations/sample-dynamic/config-samples/cp4d-409.yaml
+++ b/sample-configurations/sample-dynamic/config-samples/cp4d-409.yaml
@@ -3,7 +3,8 @@ cp4d:
 
 - project: zen-40
   openshift_cluster_name: "{{ env_id }}"
-  cp4d_version: 4.0
+  cp4d_version: 4.0.9
+  olm_utils: False
   use_case_files: True
   accept_licenses: False
   cartridges:
@@ -11,14 +12,10 @@ cp4d:
     license_service:
       state: disabled
       threads_per_core: 2
-    case_version: 1.14.0
+  
   - name: lite
-    subscription_channel: v2.0
-    case_version: 2.0.13
+
   - name: scheduler 
-    version: 1.3.5
-    subscription_channel: v1.3
-    case_version: 1.3.5
     state: removed
     
 #
@@ -31,22 +28,13 @@ cp4d:
 #
 
   - name: analyticsengine 
-    version: 4.0.9
-    subscription_channel: stable-v1
-    case_version: 4.0.9
     size: small 
     state: removed
 
   - name: bigsql
-    version: 7.2.8
-    subscription_channel: v7.2
-    case_version: 7.2.8
     state: removed
 
   - name: ca
-    version: 4.0.8
-    subscription_channel: v4.0
-    case_version: 4.0.10
     size: small
     instances:
     - name: ca-instance
@@ -54,27 +42,15 @@ cp4d:
     state: removed
 
   - name: cde
-    version: 4.0.9
-    subscription_channel: v1.0
-    case_version: 2.0.9
     state: removed
 
   - name: datagate
-    version: 2.0.8
-    subscription_channel: v2.0
-    case_version: 4.0.8
     state: removed
 
   - name: datastage-ent-plus
-    version: 4.0.9
-    subscription_channel: v1.0
-    case_version: 4.0.10
     state: removed
 
   - name: db2
-    version: 4.0.10
-    subscription_channel: v1.0
-    case_version: 4.0.10
     size: small
     instances:
     - name: ca-metastore
@@ -85,27 +61,15 @@ cp4d:
     state: removed
 
   - name: db2u
-    version: 4.0.10
-    subscription_channel: v1.1
-    case_version: 4.0.10
     state: removed
 
   - name: db2wh
-    version: 4.0.10
-    subscription_channel: v1.0
-    case_version: 4.0.10
     state: removed
 
   - name: dmc
-    version: 4.0.8
-    subscription_channel: v1.0
-    case_version: 4.0.8
     state: removed
 
   - name: dods
-    version: 4.0.9
-    subscription_channel: v4.0
-    case_version: 4.0.9
     size: small
     dependencies:
     - name: wsl
@@ -113,16 +77,10 @@ cp4d:
     state: removed
 
   - name: dp
-    version: 4.0.9
-    subscription_channel: v1.0
-    case_version: 4.0.9
     size: small
     state: removed
 
   - name: dv
-    version: 1.7.8
-    subscription_channel: v1.7
-    case_version: 1.7.8
     size: small 
     dependencies:
     - name: db2u
@@ -131,140 +89,89 @@ cp4d:
     state: removed
 
   - name: hadoop
-    version: 4.0.9
     size: small
-    subscription_channel: v1.0
-    case_version: 4.0.10
     dependencies:
     - name: wsl
     state: removed
 
   - name: mdm
-    version: 1.1.278
-    subscription_channel: v1.1
-    case_version: 1.0.209
     size: small
     wkc_enabled: true
     state: removed
 
   - name: openpages
-    version: 8.204.5
-    subscription_channel: v1.0
-    case_version: 2.1.5+20220414.030441.82040426
     state: removed
 
+  # For Planning Analytics, the case version is needed due to defect in olm utils
   - name: planning-analytics
-    version: 4.0.9
-    subscription_channel: v4.0
     case_version: 4.0.90573
     state: removed
 
   - name: rstudio
-    version: 4.0.9
-    subscription_channel: v1.0
-    case_version: 1.0.9
     size: small
     dependencies:
     - name: wsl
     state: removed
 
   - name: spss
-    version: 4.0.9
-    subscription_channel: v1.0
-    case_version: 1.0.9
     dependencies:
     - name: wsl
     state: removed
 
   - name: voice-gateway
-    version: 1.0.8
-    subscription_channel: v1.0
-    case_version: 1.0.6
     replicas: 1
     state: removed
 
   - name: watson-assistant
-    version: 4.0.8
-    subscription_channel: v4.0
-    case_version: 4.0.8
     size: small
     state: removed
 
   - name: watson-discovery
-    version: 4.0.9
-    subscription_channel: v4.0
-    case_version: 4.0.9
     state: removed
 
   - name: watson-ks
-    version: 4.0.9
-    subscription_channel: v4.0
     case_version: 4.0.9
     size: small
     state: removed
 
   - name: watson-openscale
-    version: 4.0.9
-    subscription_channel: v1.5
-    case_version: 2.5.4
     size: small
     state: removed
 
   - name: watson-speech
-    version: 4.0.9
-    subscription_channel: v4.0
-    case_version: 4.0.10
     stt_size: xsmall
     tts_size: xsmall
     state: removed
 
   - name: wkc
-    version: 4.0.9
-    subscription_channel: v1.0
-    case_version: 4.0.9
     size: small
     state: removed
 
   - name: wml
-    version: 4.0.9
-    subscription_channel: v1.1
-    case_version: 4.0.10
     size: small
     state: installed
 
   - name: wml-accelerator
-    version: 2.3.9
-    subscription_channel: v1.0
-    case_version: 2.3.9
     replicas: 1
     size: small
     state: removed
 
   - name: wsl
-    version: 4.0.9
-    subscription_channel: v2.0
-    case_version: 2.0.9
     state: installed
 
 #
 # Cartridge case dependencies
 #
   - name: ccs
-    case_version: 1.0.9
 
   - name: datarefinery
-    case_version: 1.0.9
     
   - name: wsl-runtimes
-    case_version: 1.0.9
 
 #
 # Cartridges where extra work is needed (will not install automatically)
 # 
   # Product Master requires set up of the Db2 instance secret before install
   - name: productmaster
-    version: 1.0.4
-    subscription_channel: v1.0
     size: small  
-    case_version: 1.0.4+20220511.175530.3
     state: removed

--- a/sample-configurations/sample-dynamic/config-samples/cp4d-409.yaml
+++ b/sample-configurations/sample-dynamic/config-samples/cp4d-409.yaml
@@ -129,6 +129,7 @@ cp4d:
   - name: watson-discovery
     state: removed
 
+  # For Watson Knowledge Studio, the case version is needed due to defect in olm utils
   - name: watson-ks
     case_version: 4.0.9
     size: small

--- a/sample-configurations/sample-dynamic/config-samples/cp4d-409.yaml
+++ b/sample-configurations/sample-dynamic/config-samples/cp4d-409.yaml
@@ -5,6 +5,7 @@ cp4d:
   openshift_cluster_name: "{{ env_id }}"
   cp4d_version: 4.0
   use_case_files: True
+  accept_licenses: False
   cartridges:
   - name: cp-foundation
     license_service:

--- a/sample-configurations/web-ui-base-config/cloud-pak/cp4d.yaml
+++ b/sample-configurations/web-ui-base-config/cloud-pak/cp4d.yaml
@@ -3,8 +3,9 @@ cp4d:
 
 - project: zen-40
   openshift_cluster_name: "{{ env_id }}"
-  cp4d_version: 4.0
+  cp4d_version: 4.0.7
   use_case_files: True
+  olm_utils: False
   cartridges:
   - name: cp-foundation
     license_service:


### PR DESCRIPTION
Changes implemented:
#24 - Use olm-utils to retrieve the default versions of case files and operands - simplify configuration
#23 - Fix warning message that shows up when running the deployer