### PR TITLE
Fix dependabot alert

### DIFF
--- a/deployer-web/ui/package-lock.json
+++ b/deployer-web/ui/package-lock.json
@@ -13179,9 +13179,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.0.tgz",
-      "integrity": "sha512-JC6qfIEkPBd9j1SMO3Pfn+A6w2kQV54tv+ABQLgZr7dA3k/DL/OBoYSWxzVpZev3J+bUHXfr55L8Mox7AaNo6g==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -16537,7 +16537,8 @@
       }
     },
     "@svgr/webpack": {
-      "version": "https://registry.npmjs.org/@svgr/webpack/-/webpack-6.2.1.tgz",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-6.2.1.tgz",
       "integrity": "sha512-h09ngMNd13hnePwgXa+Y5CgOjzlCvfWLHg+MBnydEedAnuLRzUHUJmGS3o2OsrhxTOOqEsPOFt5v/f6C5Qulcw==",
       "requires": {
         "@babel/core": "^7.15.5",
@@ -22868,7 +22869,7 @@
       "requires": {
         "@babel/core": "^7.16.0",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
-        "@svgr/webpack": "^5.5.0",
+        "@svgr/webpack": "^6.2.1",
         "babel-jest": "^27.4.2",
         "babel-loader": "^8.2.3",
         "babel-plugin-named-asset-import": "^0.3.8",
@@ -23828,9 +23829,9 @@
       }
     },
     "terser": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.0.tgz",
-      "integrity": "sha512-JC6qfIEkPBd9j1SMO3Pfn+A6w2kQV54tv+ABQLgZr7dA3k/DL/OBoYSWxzVpZev3J+bUHXfr55L8Mox7AaNo6g==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",


### PR DESCRIPTION
Issue 75: https://github.com/IBM/cloud-pak-deployer/issues/75

No vulnerabilities now.
```
up to date, audited 1241 packages in 3s

187 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```