### PR TITLE
Renamed speech-prod-cr as speech-cr is created

### DIFF
--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/watson-speech-cr.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/templates/watson-speech-cr.j2
@@ -1,7 +1,7 @@
 apiVersion: speech.watson.ibm.com/v1
 kind: WatsonSpeech
 metadata:
-  name: speech-prod-cr     # The recommended name of the custom resource, which you can change
+  name: speech-cr     # The recommended name of the custom resource, which you can change
   namespace: {{ _p_current_cp4d_cluster.project }}
 spec:
   license:

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-variables/vars/vars-cp4d-installation.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-variables/vars/vars-cp4d-installation.yml
@@ -545,7 +545,7 @@ cartridge_cr:
     package_manifest: ibm-watson-speech-operator
     cartridge_label: operators.coreos.com/ibm-watson-speech-operator.ibm-common-services
     cr_cr: WatsonSpeech
-    cr_name: speech-prod-cr
+    cr_name: speech-cr
     cr_status_attribute: speechStatus
     cr_status_completed: Completed
     cr_operator_label: watson-speech


### PR DESCRIPTION
The validation of a successful Watson Speech install for CP4D is looking for a CR called 'speech-prod-cr', when the CR is actually called 'speech-cr'.