### PR TITLE
chore: update Event Streams CASE version

### DIFF
--- a/automation-roles/50-install-cloud-pak/cp4i/cp4i-cluster/vars/versions.yml
+++ b/automation-roles/50-install-cloud-pak/cp4i/cp4i-cluster/vars/versions.yml
@@ -41,9 +41,9 @@ version_specific_properties:
 
   - type: event-streams
     name: es1
-    version: 11.0.3
+    version: 11.0.4
     channel: v3.0
-    case_version: 1.6.5 
+    case_version: 1.6.6 
   
   - type: high-speed-transfer-server
     name: aspera1


### PR DESCRIPTION
Installing Event Streams with cloud-pak-deployer currently fails during the 
"cp4i-cluster : Create catalog source from CASE archive" task. 

The error is:

```
Prerequisite                                                        Result
Cluster has at least one amd64 or s390x node                        true
OpenShift Container Platform Kubernetes version is 1.16 or greater  true
Client has oc version 4.3.0 or greater                              true
Client has cloudctl version v3.4.1-1786 or greater                  false

Required prereqs result: FAILED
```

This is because of a problem with the version of the CASE bundle that it is
installing. Newer versions of the CASE bundle improved the regex that is used
to verify the cloudctl version, and resolved this error.

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>