### PR TITLE
drop CLF if exists

### DIFF
--- a/automation-roles/40-configure-infra/openshift-logging/tasks/configure-openshift-logging.yml
+++ b/automation-roles/40-configure-infra/openshift-logging/tasks/configure-openshift-logging.yml
@@ -109,6 +109,16 @@
     src: openshift-clusterlogforwarder-cr.j2
     dest: "{{ status_dir }}/openshift/{{ current_openshift_cluster.name }}-openshift-clusterlogforwarder-cr.yaml"
 
+- name: Get current ClusterLogForwarder 'instance', if it exists
+  shell: |
+    oc get ClusterLogForwarder -n openshift-logging | grep '^instance[[:space:]]' | wc -l
+  register: _current_clf_instance
+
+- name: Delete existing ClusterLogForwarder 'instance' if it exists
+  shell: |
+    oc delete ClusterLogForwarder instance -n openshift-logging
+  when: _current_clf_instance.stdout == "1"
+
 - name: Create ClusterLogForwarder instance
   shell: |
     oc apply -f {{ status_dir }}/openshift/{{ current_openshift_cluster.name }}-openshift-clusterlogforwarder-cr.yaml


### PR DESCRIPTION
When changes are applied to `openshift-logging` the CLF `instance` must be deleted, as oc apply cannot merge the changes. 