### PR TITLE
FIX BUG 350 : added url in the documentation

### DIFF
--- a/docs/src/50-advanced/locations-to-whitelist.md
+++ b/docs/src/50-advanced/locations-to-whitelist.md
@@ -24,6 +24,7 @@ When building or running the deployer in an environment with strict policies for
 | Location                      | Used for                                                 |
 | ----------------------------- | -------------------------------------------------------- |
 | github.com                    | Case files, Cloud Pak clients: cloudctl, cpd-cli, cpdctl |
+| gcr.io                        | Google Container Registry (GCR)                          |
 | objects.githubusercontent.com | Binary content for github.com                            |
 | raw.githubusercontent.com     | Binary content for github.com                            |
 | mirror.openshift.com          | OpenShift client                                         |


### PR DESCRIPTION
Added documentation to whitelist Google Container Registry (GCR) in the documentation