### PR TITLE
Increase db2 wait time

### DIFF
--- a/automation-roles/50-install-cloud-pak/cp4ba/db2/tasks/install.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/db2/tasks/install.yml
@@ -166,8 +166,8 @@
     name: db2ucluster
     namespace: db2
   register: db2ucluster
-  retries: 80
-  delay: 20
+  retries: 70
+  delay: 60
   until: ('Ready' in db2ucluster | json_query(state_query) | unique)
   vars:
     state_query: 'resources[*].status.state'


### PR DESCRIPTION
Increase Db2 wait time to accommodate OCP clusters where the deployment takes longer time