### PR TITLE
Upgrade Flask to 2.3.3 (Latest as of 11 Oct 23)

### DIFF
--- a/deployer-web/requirements.txt
+++ b/deployer-web/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.0.3
+Flask==2.3.3
 PyYAML==6.0
 zipfile36==0.1.3
 psutil==5.9.4


### PR DESCRIPTION
Fix for #550, upgrading Flask to 2.3.3 as the older 2.0.3 version was causing errors due to a new version of Werkzeug (3.0.0) being released which has removed some deprecated code 2.0.3 relied on.