### PR TITLE
Adding required build arguments to image build config

### DIFF
--- a/docs/src/50-advanced/run-on-openshift/build-image-and-run-deployer-on-openshift.md
+++ b/docs/src/50-advanced/run-on-openshift/build-image-and-run-deployer-on-openshift.md
@@ -219,7 +219,12 @@ spec:
       ref: wizard
   strategy:
     type: Docker
-    dockerStrategy: {}
+    dockerStrategy:
+      buildArgs:
+      - name: CPD_OLM_UTILS_V1_IMAGE
+        value: icr.io/cpopen/cpd/olm-utils:latest
+      - name: CPD_OLM_UTILS_V2_IMAGE
+        value: icr.io/cpopen/cpd/olm-utils-v2:latest
   output:
     to:
       kind: ImageStreamTag


### PR DESCRIPTION
Container build now requires arguments CPD_OLM_UTILS_V1_IMAGE and CPD_OLM_UTILS_V2_IMAGE. Adding default values to example