### PR TITLE
cpd-cli version depending of arch

### DIFF
--- a/automation-roles/99-generic/cpd-cli/cpd-cli-download/tasks/cpd-cli-download.yml
+++ b/automation-roles/99-generic/cpd-cli/cpd-cli-download/tasks/cpd-cli-download.yml
@@ -12,6 +12,14 @@
   vars:
     query: >-
       [?starts_with(name,'cpd-cli-linux-EE')].browser_download_url 
+  when: _cpd_cli_arch == "amd64"
+
+- set_fact:
+    _cpd_cli_download_url: "{{ _cpd_cli_releases.json.assets | json_query(query) | first }}"
+  vars:
+    query: >-
+      [?starts_with(name,'cpd-cli-{{ _cpd_cli_arch }}-EE')].browser_download_url
+  when: _cpd_cli_arch != "amd64"
 
 - name: Download latest cpd-cli release
   get_url:


### PR DESCRIPTION
Fetch the right cpd-cli version when arch is not Intel.