### PR TITLE
add lite_install check to prep-watsonx-ai

### DIFF
--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/tasks/cp4d-prep-watsonx-ai.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cartridge-install/tasks/cp4d-prep-watsonx-ai.yml
@@ -6,3 +6,4 @@
     block: |2
         watsonx_ai:
           tuning_disabled: {{ _current_cp4d_cartridge.installation_options.tuning_disabled | default(false) }}
+          lite_install: {{ _current_cp4d_cartridge.installation_options.lite_install | default(false) }}


### PR DESCRIPTION
Tested this with an OCP 4.15 cluster with 5.0.1 cp4d and it added it to the spec when building watsonx.ai correctly. This fix applies to #762.

![image](https://github.com/user-attachments/assets/b65543f5-df77-47ce-b069-f8b6120a4d8a)

Also tested it with an OCP 4.14 cluster with 4.8.4 cp4d and it didn't cause any problems during the installation with it not being defined in the cloud-pak-deployer configmap or being automatically added as false to the watsonxai-cr.

![image](https://github.com/user-attachments/assets/da19e18b-2f3b-4836-803d-66d6723fb996)
