### PR TITLE
Air-gapped fixes

### DIFF
--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-cluster/tasks/openshift-install-knative.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-cluster/tasks/openshift-install-knative.yml
@@ -2,6 +2,33 @@
 
 # Prepare CP4D for versions >= 4.8.0
 - block:
+
+  - name: Create the catalog source for IBM Events operator when in air-gapped environment. deploy-knative-eventing doesn't manage local case files
+    block:
+    - name: Get the cpfs case version
+      shell: yq ".release_components_meta.cpfs.case_version" /opt/ansible/ansible-play/config-vars/release-{{ current_cp4d_cluster.cp4d_version }}.yml
+      register: _cpfs_case_version
+
+    - name: Unpack case file {{ status_dir }}/work/offline/{{ current_cp4d_cluster.cp4d_version }}/.ibm-pak/data/cases/ibm-cp-common-services/{{ _cpfs_case_version.stdout }}/ibm-cp-common-services-{{ _cpfs_case_version }}.tgz to /tmp
+      unarchive:
+        src: "{{ status_dir }}/work/offline/{{ current_cp4d_cluster.cp4d_version }}/.ibm-pak/data/cases/ibm-cp-common-services/{{ _cpfs_case_version.stdout }}/ibm-cp-common-services-{{ _cpfs_case_version.stdout }}.tgz"
+        dest: /tmp
+        remote_src: True
+
+    - name: Create OpenShift Project ibm-knative-events
+      shell: 
+        oc new-project ibm-knative-events || true
+
+    - name: Create catalog source
+      shell: |
+        oc patch --filename=/tmp/ibm-cp-common-services/inventory/ibmCommonServiceOperatorSetup/files/op-olm/catalog_source.yaml \
+          --type=merge \
+          -o yaml \
+          --patch='{"metadata": {"namespace": "ibm-knative-events"}}' \
+          --dry-run=client | oc apply -n ibm-knative-events -f -
+    
+    when: cpd_airgap | bool
+
   - name: Generate deploy KNative eventing script {{ status_dir }}/cp4d/{{ current_cp4d_cluster.project }}-deploy-knative-eventing.sh
     template:
       src: deploy-knative-eventing.j2

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-mirror-images/tasks/main.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-mirror-images/tasks/main.yml
@@ -94,6 +94,13 @@
       state: absent
   when: _p_current_cp4d_cluster.cp4d_version == '4.8.5'
 
+- name: Copy CASE packages from {{ status_dir }}/work/ to /tmp/work/offline (air-gapped scenario) 
+  copy:
+    src: "{{ status_dir }}/work/offline"
+    dest: /tmp/work/
+    remote_src: True
+  when: _p_source_registry_hostname | default('') == _v_portable_registry
+
 - name: Generate script to copy mirroring log files {{ _p_current_cp4d_cluster.project }}-mirror-images-copy-log-files.sh
   template:
     src: mirror-images-copy-log-files.j2
@@ -124,16 +131,20 @@
   failed_when: False
   register: _mirror_images
 
-- name: Remove {{ status_dir }}/work/offline
-  ansible.builtin.file:
-    path: "{{ status_dir }}/work/offline"
-    state: absent
+- block:
 
-- name: Copy mirror-images assets from /tmp/work/offline to {{ status_dir }}/work/
-  copy:
-    src: /tmp/work/offline
-    dest: "{{ status_dir }}/work/"
-    remote_src: True
+  - name: Remove {{ status_dir }}/work/offline
+    ansible.builtin.file:
+      path: "{{ status_dir }}/work/offline"
+      state: absent
+
+  - name: Copy mirror-images assets from /tmp/work/offline to {{ status_dir }}/work/
+    copy:
+      src: /tmp/work/offline
+      dest: "{{ status_dir }}/work/"
+      remote_src: True
+  
+  when: _p_source_registry_hostname | default('') != _v_portable_registry
 
 - name: Stop script that mirrors log files
   file:

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-mirror-images/tasks/main.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-mirror-images/tasks/main.yml
@@ -105,7 +105,84 @@
   template:
     src: mirror-images-copy-log-files.j2
     dest: "{{ status_dir}}/cp4d/{{ _p_current_cp4d_cluster.project }}-mirror-images-copy-log-files.sh"
-    mode: u+rwx
+    mode: u+rwx   
+
+- name: Run script that copies mirror log files in background
+  shell: |
+    {{ status_dir}}/cp4d/{{ _p_current_cp4d_cluster.project }}-mirror-images-copy-log-files.sh
+  async: 86400
+  poll: 0
+
+- name: Collect the cartridges to be mirrored
+  set_fact:
+    _cartridges_to_mirror_list: "{{ _cartridges_to_install_list }}"
+
+- block:
+  - name: Collect foundation models to be installed
+    set_fact:
+      _models_to_install: "{{ _cartridges_to_install | json_query(jsonquery) | selectattr('state','match','installed') | map(attribute='model_id') }}"
+    vars:
+      jsonquery: "[?olm_utils_name=='watsonx_ai'].models[]"
+
+  - block:
+    - name: Filter the list of cartriges to exclude watsonx_ai_ifm from regular mirroring
+      set_fact:
+        _cartridges_to_mirror_list: "{{ _cartridges_to_install | map(attribute='olm_utils_name') | reject('equalto', 'watsonx_ai_ifm') | join(',') }}"
+   
+    - name: Get the watsonx_ai_ifm case version
+      shell: yq ".release_components_meta.watsonx_ai_ifm.case_version" /opt/ansible/ansible-play/config-vars/release-{{ _p_current_cp4d_cluster.cp4d_version }}.yml
+      register: _watsonx_ai_ifm_case_version
+
+    - name: Find watsonx_ai_ifm images csv file
+      find:
+        paths: "{{ status_dir }}/work/offline/{{ _p_current_cp4d_cluster.cp4d_version }}/.ibm-pak/data/cases/ibm-watsonx-ai-ifm/{{ _watsonx_ai_ifm_case_version.stdout }}"
+        patterns: '*-images.csv'
+      register: _watsonx_ai_ifm_images_files
+
+    - name: Read watsonx_ai_ifm images csv file
+      read_csv:
+        path: "{{ (_watsonx_ai_ifm_images_files.files | first).path }}"
+        skipinitialspace: True
+      register: _watsonx_ai_ifm_images_json
+
+    - name: Initialize group list
+      set_fact:
+        _case_groups: []
+
+    - name: Collect case groups for models
+      set_fact:
+        _case_groups: "{{ _case_groups + _watsonx_ai_ifm_images_json.list | selectattr('image_name','search',item) | map(attribute='groups') | unique }}"
+      loop: "{{ _models_to_install }}"
+
+    - debug: var=_case_groups
+
+    - name: Create case group list
+      set_fact:
+        _case_group_list: "{{ _case_groups | join(',') }}"
+      
+    - name: Generate script to mirror foundation model images {{ _p_current_cp4d_cluster.project }}-mirror-model-images.sh
+      template:
+        src: mirror-model-images.j2
+        dest: "{{ status_dir}}/cp4d/{{ _p_current_cp4d_cluster.project }}-mirror-model-images.sh"
+        mode: u+rwx
+      vars:
+        _p_preview_script: False
+
+    - name: Show script that will mirror model images {{ status_dir}}/cp4d/{{ _p_current_cp4d_cluster.project }}-mirror-model-images.sh
+      debug:
+        msg: "{{ lookup('file', status_dir + '/cp4d/' + _p_current_cp4d_cluster.project + '-mirror-model-images.sh' ) }}"
+
+    - name: Mirror model images, log is in {{ status_dir }}/log/{{ _p_current_cp4d_cluster.project }}-mirror-model-images.log; detailed logs can be found in {{ status_dir }}/log/mirror_*.log
+      shell: |
+        {{ status_dir}}/cp4d/{{ _p_current_cp4d_cluster.project }}-mirror-model-images.sh
+      failed_when: False
+      register: _mirror_model_images
+    
+    when: _models_to_install | length > 0
+
+  when:
+    - _p_current_cp4d_cluster.cp4d_version >= '5.0.1'
+    - '"watsonx_ai" in _cartridges_to_install_list'  
 
 - name: Generate script to mirror images {{ _p_current_cp4d_cluster.project }}-mirror-images.sh
   template:
@@ -118,12 +195,6 @@
 - name: Show script that will mirror images {{ status_dir}}/cp4d/{{ _p_current_cp4d_cluster.project }}-mirror-images.sh
   debug:
     msg: "{{ lookup('file', status_dir + '/cp4d/' + _p_current_cp4d_cluster.project + '-mirror-images.sh' ) }}"
-
-- name: Run script that copies mirror log files in background
-  shell: |
-    {{ status_dir}}/cp4d/{{ _p_current_cp4d_cluster.project }}-mirror-images-copy-log-files.sh
-  async: 86400
-  poll: 0
 
 - name: Mirror images, log is in {{ status_dir }}/log/{{ _p_current_cp4d_cluster.project }}-mirror-images.log; detailed logs can be found in {{ status_dir }}/log/mirror_*.log
   shell: |
@@ -161,4 +232,4 @@
 
 - fail:
     msg: Mirroring of images failed, check mirror*.log files in {{ status_dir }}/log for details
-  when: _mirror_images.rc != 0
+  when: _mirror_images.rc != 0 or (_mirror_model_images is defined and _mirror_model_images.rc != 0)

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-mirror-images/templates/mirror-images.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-mirror-images/templates/mirror-images.j2
@@ -11,4 +11,4 @@ mirror-images \
     --arch={{ _openshift_processor_arch }} \
     --preview={%- if _p_preview_script -%}true{%- else -%}false{%- endif %} \
     -v \
-    --case-download={%- if cpd_airgap | default(False) -%}false{%- else -%}true{%- endif %} 2>&1 | tee {{ status_dir }}/log/{{ _p_current_cp4d_cluster.project }}-mirror-images.log 
+    --case_download={%- if cpd_airgap | default(False) -%}false{%- else -%}true{%- endif %} 2>&1 | tee {{ status_dir }}/log/{{ _p_current_cp4d_cluster.project }}-mirror-images.log 

--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-mirror-images/templates/mirror-model-images.j2
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-mirror-images/templates/mirror-model-images.j2
@@ -3,7 +3,7 @@
 set -o pipefail
 mirror-images \
     --release={{ _p_current_cp4d_cluster.cp4d_version }} \
-    --components={%- if _p_current_cp4d_cluster.cp4d_version >= '4.7.0' %}ibm-cert-manager,ibm-licensing,{%- endif %}{{ _cartridges_to_mirror_list }} \
+    --components=watsonx_ai_ifm \
 {% if (_p_source_registry_hostname | default('')) == _v_portable_registry -%}
     --source_registry={{ _v_portable_registry }}:{{ _v_portable_registry_port }} \
 {% endif -%}    
@@ -11,4 +11,5 @@ mirror-images \
     --arch={{ _openshift_processor_arch }} \
     --preview={%- if _p_preview_script -%}true{%- else -%}false{%- endif %} \
     -v \
-    --case_download={%- if cpd_airgap | default(False) -%}false{%- else -%}true{%- endif %} 2>&1 | tee {{ status_dir }}/log/{{ _p_current_cp4d_cluster.project }}-mirror-images.log 
+    --groups={{ _case_group_list }} \
+    --case_download={%- if cpd_airgap | default(False) -%}false{%- else -%}true{%- endif %} 2>&1 | tee {{ status_dir }}/log/{{ _p_current_cp4d_cluster.project }}-mirror-model-images.log 

--- a/automation-roles/99-generic/cpd-cli/cpd-cli-download/tasks/main.yml
+++ b/automation-roles/99-generic/cpd-cli/cpd-cli-download/tasks/main.yml
@@ -11,10 +11,14 @@
   when: ARCH != 'x86_64'
   
 - include_tasks: cpd-cli-download.yml
-  when: (_github_ibm_pat | default('')) == ''
+  when:
+    - (_github_ibm_pat | default('')) == ''
+    - not (cpd_airgap | bool)
 
 - include_tasks: cpd-cli-download-github-pat.yml
-  when: (_github_ibm_pat | default('')) != ''
+  when:
+    - (_github_ibm_pat | default('')) != ''
+    - not (cpd_airgap | bool)
 
 - name: Unpack cpd-cli from {{ status_dir }}/downloads/cpd-cli-linux-{{ _cpd_cli_arch }}.tar.gz
   unarchive:


### PR DESCRIPTION
Includes the following changes:
- Fixes issue when air-gapped where playbook is trying to check version of cpd-cli. Disabled check when in airgap mode
- Fixes issue with case file downloads. Typo on command to download case files (`case_download` instead of `case-download`)
- Fixes issue when in airgap mode and case files are deleted from cpd-status directory
- Workaround for issue in olm-utils when ibm events operator is being installed. Adding catalog source as part of ibm events operator install
- Adding support for only mirroring the foundation model images that are selected for install