### PR TITLE
update logic for nfd operator image

### DIFF
--- a/automation-roles/40-configure-infra/nfd-operator/templates/nfd-cr.j2
+++ b/automation-roles/40-configure-infra/nfd-operator/templates/nfd-cr.j2
@@ -8,7 +8,7 @@ spec:
   instance: "" # instance is empty by default
   topologyupdater: false # False by default
   operand:
-{% if _p_current_ocp_version >= 4.15 %}
+{% if _p_current_ocp_version >= '4.15' %}
     image: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v{{ _p_current_ocp_version }}
 {% else %}
     image: registry.redhat.io/openshift4/ose-node-feature-discovery:v{{ _p_current_ocp_version }}

--- a/automation-roles/40-configure-infra/nfd-operator/templates/nfd-cr.j2
+++ b/automation-roles/40-configure-infra/nfd-operator/templates/nfd-cr.j2
@@ -8,7 +8,7 @@ spec:
   instance: "" # instance is empty by default
   topologyupdater: false # False by default
   operand:
-{% if _p_current_ocp_version == '4.15' %}
+{% if _p_current_ocp_version|float() >= 4.15 %}
     image: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v{{ _p_current_ocp_version }}
 {% else %}
     image: registry.redhat.io/openshift4/ose-node-feature-discovery:v{{ _p_current_ocp_version }}

--- a/automation-roles/40-configure-infra/nfd-operator/templates/nfd-cr.j2
+++ b/automation-roles/40-configure-infra/nfd-operator/templates/nfd-cr.j2
@@ -8,7 +8,7 @@ spec:
   instance: "" # instance is empty by default
   topologyupdater: false # False by default
   operand:
-{% if _p_current_ocp_version|float() >= 4.15 %}
+{% if _p_current_ocp_version >= 4.15 %}
     image: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v{{ _p_current_ocp_version }}
 {% else %}
     image: registry.redhat.io/openshift4/ose-node-feature-discovery:v{{ _p_current_ocp_version }}


### PR DESCRIPTION
Tested this on 3 different clusters with OCP versions 4.14, 4.15, and 4.16 and correct version of nfd operator was installed and installation completed successfully.
![image](https://github.com/user-attachments/assets/ba619b20-bad0-4591-9bdd-28d2fa50b0d8)
![image](https://github.com/user-attachments/assets/8368b9f8-883a-465f-bff0-57a5fd638d25)
![image](https://github.com/user-attachments/assets/d19dec6a-be53-4b57-bef5-ade5c52389c7)

This fixes #754.