### PR TITLE
Fix project assignment and improve project existence checks in subscr…

### DIFF
--- a/scripts/cp4d/cp4d-olm-status.sh
+++ b/scripts/cp4d/cp4d-olm-status.sh
@@ -1,16 +1,25 @@
 #!/bin/bash
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )
 
-# Determine the project that runs the operators
-oc get project ibm-common-services > /dev/null 2>&1
-if [ $? -eq 0 ];then
-  fs_project="ibm-common-services"
-else
-  fs_project=cpd-operators"
+
+# Check if PROJECT_CPD_INST_OPERATORS and PROJECT_CPD_INST_OPERANDS are set, otherwise throw an error
+if [ -z "${PROJECT_CPD_INST_OPERATORS}" ] || [ -z "${PROJECT_CPD_INST_OPERANDS}" ]; then
+  echo "Error: Environment variables PROJECT_CPD_INST_OPERATORS or PROJECT_CPD_INST_OPERANDS are not set."
+  echo "Please source the cpd_vars file or define them"
+  exit 1
 fi
 
-echo "Listing subscriptions and their CSVs"
-oc get sub -n ${fs_project} \
-    --sort-by=.metadata.creationTimestamp \
-    --no-headers \
-    -o jsonpath='{range .items[*]}{.metadata.name}{","}{.metadata.creationTimestamp}{","}{.status.installedCSV}{","}{.status.state}{"\n"}{end}'
+#Operators Project
+fs_project=${PROJECT_CPD_INST_OPERATORS}
+
+# List subscriptions and their CSVs
+if oc get project ${fs_project} > /dev/null 2>&1; then
+  echo "Listing subscriptions and their CSVs"
+  oc get sub -n ${fs_project} \
+      --sort-by=.metadata.creationTimestamp \
+      --no-headers \
+      -o jsonpath='{range .items[*]}{.metadata.name}{","}{.metadata.creationTimestamp}{","}{.status.installedCSV}{","}{.status.state}{"\n"}{end}'
+else
+  echo "Error: Project ${fs_project} does not exist or cannot be accessed."
+  exit 1
+fi


### PR DESCRIPTION
- Added a check to verify whether the determined project (fs_project) exists and is accessible before attempting to list subscriptions. If the project cannot be accessed, an appropriate error message is displayed, and the script exits gracefully. 
- Add a check to very jq is present otherwise install (Debian and RH compatible)

