### PR TITLE
[CP4BA] Cleaning PostgreSQL scripts

### DIFF
--- a/automation-roles/50-install-cloud-pak/cp4ba/common/tasks/remove-postgresql-tablespace.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/common/tasks/remove-postgresql-tablespace.yml
@@ -1,6 +1,6 @@
 # Example of the functionality call
 #
-# - name: Remove PostgreSQL tablespace
+# - name: Remove PostgreSQL tablespace and folder
 #   ansible.builtin.include_role:
 #     name: common
 #     tasks_from: remove-postgresql-tablespace
@@ -24,7 +24,7 @@
     command: >
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
-        DROP TABLESPACE IF EXISTS {{ common_postgresql_tablespace_name }}_tbs;
+        DROP TABLESPACE IF EXISTS {{ common_postgresql_tablespace_name }};
       EOF"
   register: command_status
   when: postgresql_pod.resources | length != 0

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae-data-persistence.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae-data-persistence.yml
@@ -28,11 +28,10 @@
         -- create user aeos
         CREATE USER aeos WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database aeos
-        create database aeos owner aeos template template0 encoding UTF8;
-        revoke connect on database aeos from public;
+        -- create tablespace for aeos
+        CREATE TABLESPACE aeos_tbs OWNER aeos LOCATION '/bitnami/postgresql/tablespaces/aeos';
 
-        -- please modify location follow your requirement
-        create tablespace aeos_tbs owner aeos location '/bitnami/postgresql/tablespaces/aeos';
+        -- create database aeos
+        CREATE DATABASE aeos OWNER aeos TEMPLATE template0 ENCODING UTF8 TABLESPACE aeos_tbs;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae-data-persistence.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae-data-persistence.yml
@@ -29,7 +29,7 @@
         CREATE USER aeos WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create tablespace for aeos
-        CREATE TABLESPACE aeos_tbs OWNER aeos LOCATION '/bitnami/postgresql/tablespaces/aeos';
+        CREATE TABLESPACE aeos_tbs OWNER aeos LOCATION '/bitnami/postgresql/tablespaces/aeos_tbs';
 
         -- create database aeos
         CREATE DATABASE aeos OWNER aeos TEMPLATE template0 ENCODING UTF8 TABLESPACE aeos_tbs;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae-data-persistence.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae-data-persistence.yml
@@ -33,5 +33,6 @@
 
         -- create database aeos
         CREATE DATABASE aeos OWNER aeos TEMPLATE template0 ENCODING UTF8 TABLESPACE aeos_tbs;
+        REVOKE CONNECT ON DATABASE aeos FROM PUBLIC;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae-data-persistence.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae-data-persistence.yml
@@ -26,7 +26,7 @@
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
         -- create user aeos
-        CREATE ROLE aeos WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
+        CREATE USER aeos WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database aeos
         create database aeos owner aeos template template0 encoding UTF8;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae-data-persistence.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae-data-persistence.yml
@@ -31,11 +31,8 @@
         -- create database aeos
         create database aeos owner aeos template template0 encoding UTF8;
         revoke connect on database aeos from public;
-        grant all privileges on database aeos to aeos;
-        grant connect, temp, create on database aeos to aeos;
 
         -- please modify location follow your requirement
         create tablespace aeos_tbs owner aeos location '/bitnami/postgresql/tablespaces/aeos';
-        grant create on tablespace aeos_tbs to aeos;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae-data-persistence.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae-data-persistence.yml
@@ -14,7 +14,7 @@
   kubernetes.core.k8s_exec:
     namespace: "{{ cp4ba_postgresql_project }}"
     pod: "{{ postgresql_pod.resources[0].metadata.name }}"
-    command: mkdir -p /bitnami/postgresql/tablespaces/aeos
+    command: mkdir -p /bitnami/postgresql/tablespaces/aeos_tbs
   register: command_status
   failed_when: command_status.rc != 0 and command_status.stderr is not search('.*File exists.*')
 

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae.yml
@@ -16,8 +16,8 @@
     command: >
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
-        -- create a new user
-        create user aaedb with password '{{ cp4ba_postgresql_universal_password }}';
+        -- create user aaedb
+        CREATE USER aaedb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database aaedb
         create database aaedb owner aaedb;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae.yml
@@ -19,7 +19,7 @@
         -- create user aaedb
         CREATE USER aaedb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database aaedb
-        create database aaedb owner aaedb;
+        -- create database aaedb -- default template tablespace
+        CREATE DATABASE aaedb OWNER aaedb TEMPLATE template0 ENCODING UTF8;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae.yml
@@ -21,8 +21,5 @@
 
         -- create database aaedb
         create database aaedb owner aaedb;
-
-        -- The following grant is used for databases
-        grant all privileges on database aaedb to aaedb;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/aae.yml
@@ -21,5 +21,6 @@
 
         -- create database aaedb -- default template tablespace
         CREATE DATABASE aaedb OWNER aaedb TEMPLATE template0 ENCODING UTF8;
+        REVOKE CONNECT ON DATABASE aaedb FROM PUBLIC;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
@@ -20,7 +20,6 @@
         -- create database adpbase
         create database adpbase owner adpbase template template0 encoding UTF8;
         revoke connect on database adpbase from public;
-        grant all privileges on database adpbase to adpbase;
       EOF"
   register: command_status
 
@@ -37,7 +36,6 @@
         -- create database {{ item }}
         create database {{ item }} owner {{ item }} template template0 encoding UTF8;
         revoke connect on database {{ item }} from public;
-        grant all privileges on database {{ item }} to {{ item }};
       EOF"
   register: command_status
   with_items:
@@ -72,12 +70,9 @@
         -- create database devos1
         create database devos1 owner devos1 template template0 encoding UTF8;
         revoke connect on database devos1 from public;
-        grant all privileges on database devos1 to devos1;
-        grant connect, temp, create on database devos1 to devos1;
 
         -- please modify location follow your requirement
         create tablespace devos1_tbs owner devos1 location '/bitnami/postgresql/tablespaces/devos1';
-        grant create on tablespace devos1_tbs to devos1;
       EOF"
   register: command_status
 

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
@@ -17,8 +17,8 @@
         -- create user adpbase
         CREATE USER adpbase WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database adpbase
-        create database adpbase owner adpbase template template0 encoding UTF8;
+        -- create database adpbase -- default template tablespace
+        CREATE DATABASE adpbase OWNER adpbase TEMPLATE template0 ENCODING UTF8;
         revoke connect on database adpbase from public;
       EOF"
   register: command_status
@@ -33,8 +33,8 @@
         -- create user {{ item }}
         CREATE USER {{ item }} WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database {{ item }}
-        create database {{ item }} owner {{ item }} template template0 encoding UTF8;
+        -- create database {{ item }} -- default template tablespace
+        CREATE DATABASE {{ item }} OWNER {{ item }} TEMPLATE template0 ENCODING UTF8;
         revoke connect on database {{ item }} from public;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
@@ -19,7 +19,7 @@
 
         -- create database adpbase -- default template tablespace
         CREATE DATABASE adpbase OWNER adpbase TEMPLATE template0 ENCODING UTF8;
-        revoke connect on database adpbase from public;
+        REVOKE CONNECT ON DATABASE adpbase FROM PUBLIC;
       EOF"
   register: command_status
 
@@ -35,7 +35,7 @@
 
         -- create database {{ item }} -- default template tablespace
         CREATE DATABASE {{ item }} OWNER {{ item }} TEMPLATE template0 ENCODING UTF8;
-        revoke connect on database {{ item }} from public;
+        REVOKE CONNECT ON DATABASE {{ item }} FROM PUBLIC;
       EOF"
   register: command_status
   with_items:
@@ -72,6 +72,7 @@
 
         -- create database devos1
         CREATE DATABASE devos1 OWNER devos1 TEMPLATE template0 ENCODING UTF8 TABLESPACE devos1_tbs;
+        REVOKE CONNECT ON DATABASE devos1 FROM PUBLIC;
       EOF"
   register: command_status
 

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
@@ -15,7 +15,7 @@
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
         -- create user adpbase
-        CREATE ROLE adpbase WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
+        CREATE USER adpbase WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database adpbase
         create database adpbase owner adpbase template template0 encoding UTF8;
@@ -32,7 +32,7 @@
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
         -- create user {{ item }}
-        CREATE ROLE {{ item }} WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
+        CREATE USER {{ item }} WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database {{ item }}
         create database {{ item }} owner {{ item }} template template0 encoding UTF8;
@@ -67,7 +67,7 @@
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
         -- create user devos1
-        CREATE ROLE devos1 WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
+        CREATE USER devos1 WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database devos1
         create database devos1 owner devos1 template template0 encoding UTF8;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
@@ -68,7 +68,7 @@
         CREATE USER devos1 WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create tablespace for devos1
-        CREATE TABLESPACE devos1_tbs OWNER devos1 LOCATION '/bitnami/postgresql/tablespaces/devos1';
+        CREATE TABLESPACE devos1_tbs OWNER devos1 LOCATION '/bitnami/postgresql/tablespaces/devos1_tbs';
 
         -- create database devos1
         CREATE DATABASE devos1 OWNER devos1 TEMPLATE template0 ENCODING UTF8 TABLESPACE devos1_tbs;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
@@ -48,23 +48,6 @@
     - proj5
     - proj6
 
-- name: ADP proj2 DB
-  kubernetes.core.k8s_exec:
-    namespace: "{{ cp4ba_postgresql_project }}"
-    pod: "{{ postgresql_pod.resources[0].metadata.name }}"
-    command: >
-      bash -c "
-        psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
-        -- create user proj2
-        CREATE ROLE proj2 WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
-
-        -- create database proj2
-        create database proj2 owner proj2 template template0 encoding UTF8;
-        revoke connect on database proj2 from public;
-        grant all privileges on database proj2 to proj2;
-      EOF"
-  register: command_status
-
 # Based on https://www.ibm.com/docs/en/cloud-paks/cp-biz-automation/latest?topic=scripts-creating-databases-document-processing
 # DEVOS Based on
 # https://www.ibm.com/docs/en/filenet-p8-platform/latest?topic=vtpiicd-creating-postgresql-database-table-spaces-content-platform-engine-object-store

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
@@ -67,12 +67,11 @@
         -- create user devos1
         CREATE USER devos1 WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database devos1
-        create database devos1 owner devos1 template template0 encoding UTF8;
-        revoke connect on database devos1 from public;
+        -- create tablespace for devos1
+        CREATE TABLESPACE devos1_tbs OWNER devos1 LOCATION '/bitnami/postgresql/tablespaces/devos1';
 
-        -- please modify location follow your requirement
-        create tablespace devos1_tbs owner devos1 location '/bitnami/postgresql/tablespaces/devos1';
+        -- create database devos1
+        CREATE DATABASE devos1 OWNER devos1 TEMPLATE template0 ENCODING UTF8 TABLESPACE devos1_tbs;
       EOF"
   register: command_status
 

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/adp.yml
@@ -53,7 +53,7 @@
   kubernetes.core.k8s_exec:
     namespace: "{{ cp4ba_postgresql_project }}"
     pod: "{{ postgresql_pod.resources[0].metadata.name }}"
-    command: mkdir -p /bitnami/postgresql/tablespaces/devos1
+    command: mkdir -p /bitnami/postgresql/tablespaces/devos1_tbs
   register: command_status
   failed_when: command_status.rc != 0 and command_status.stderr is not search('.*File exists.*')
 

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ban.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ban.yml
@@ -28,11 +28,11 @@
         -- create user icndb
         CREATE USER icndb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database icndb
-        create database icndb owner icndb template template0 encoding UTF8 ;
-        revoke connect on database icndb from public;
 
-        -- please modify location follow your requirement
-        create tablespace icndb_tbs owner icndb location '/bitnami/postgresql/tablespaces/icndb';
+        -- create tablespace for icndb
+        CREATE TABLESPACE icndb_tbs OWNER icndb LOCATION '/bitnami/postgresql/tablespaces/icndb';
+
+        -- create database icndb
+        CREATE DATABASE icndb OWNER icndb TEMPLATE template0 ENCODING UTF8 TABLESPACE icndb_tbs;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ban.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ban.yml
@@ -31,11 +31,8 @@
         -- create database icndb
         create database icndb owner icndb template template0 encoding UTF8 ;
         revoke connect on database icndb from public;
-        grant all privileges on database icndb to icndb;
-        grant connect, temp, create on database icndb to icndb;
 
         -- please modify location follow your requirement
         create tablespace icndb_tbs owner icndb location '/bitnami/postgresql/tablespaces/icndb';
-        grant create on tablespace icndb_tbs to icndb;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ban.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ban.yml
@@ -14,7 +14,7 @@
   kubernetes.core.k8s_exec:
     namespace: "{{ cp4ba_postgresql_project }}"
     pod: "{{ postgresql_pod.resources[0].metadata.name }}"
-    command: mkdir -p /bitnami/postgresql/tablespaces/icndb
+    command: mkdir -p /bitnami/postgresql/tablespaces/icndb_tbs
   register: command_status
   failed_when: command_status.rc != 0 and command_status.stderr is not search('.*File exists.*')
 

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ban.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ban.yml
@@ -30,7 +30,7 @@
 
 
         -- create tablespace for icndb
-        CREATE TABLESPACE icndb_tbs OWNER icndb LOCATION '/bitnami/postgresql/tablespaces/icndb';
+        CREATE TABLESPACE icndb_tbs OWNER icndb LOCATION '/bitnami/postgresql/tablespaces/icndb_tbs';
 
         -- create database icndb
         CREATE DATABASE icndb OWNER icndb TEMPLATE template0 ENCODING UTF8 TABLESPACE icndb_tbs;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ban.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ban.yml
@@ -26,7 +26,7 @@
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
         -- create user icndb
-        CREATE ROLE icndb WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
+        CREATE USER icndb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database icndb
         create database icndb owner icndb template template0 encoding UTF8 ;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ban.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ban.yml
@@ -34,5 +34,6 @@
 
         -- create database icndb
         CREATE DATABASE icndb OWNER icndb TEMPLATE template0 ENCODING UTF8 TABLESPACE icndb_tbs;
+        REVOKE CONNECT ON DATABASE icndb FROM PUBLIC;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bas.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bas.yml
@@ -20,9 +20,6 @@
 
         -- create database appdb
         create database appdb owner appdb;
-
-        -- The following grant is used for databases
-        grant all privileges on database appdb to appdb;
       EOF"
   register: command_status
 
@@ -39,7 +36,6 @@
 
         -- create the database:
         CREATE DATABASE basdb WITH OWNER basdb ENCODING 'UTF8';
-        GRANT ALL ON DATABASE basdb to basdb;
 
         -- Connect to your database and create schema
         \c basdb;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bas.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bas.yml
@@ -20,6 +20,7 @@
 
         -- create database appdb -- default template tablespace
         CREATE DATABASE appdb OWNER appdb TEMPLATE template0 ENCODING UTF8;
+        REVOKE CONNECT ON DATABASE appdb FROM PUBLIC;
       EOF"
   register: command_status
 
@@ -36,6 +37,7 @@
 
         -- create database basdb -- default template tablespace
         CREATE DATABASE basdb OWNER basdb TEMPLATE template0 ENCODING UTF8;
+        REVOKE CONNECT ON DATABASE basdb FROM PUBLIC;
 
         -- Connect to your database and create schema
         \c basdb;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bas.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bas.yml
@@ -40,6 +40,6 @@
         -- Connect to your database and create schema
         \c basdb;
         SET ROLE basdb;
-        CREATE SCHEMA IF NOT EXISTS basdb AUTHORIZATION basdb;
+        CREATE SCHEMA IF NOT EXISTS basdb;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bas.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bas.yml
@@ -15,8 +15,8 @@
     command: >
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
-        -- create a new user
-        create user appdb with password '{{ cp4ba_postgresql_universal_password }}';
+        -- create user appdb
+        CREATE USER appdb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database appdb
         create database appdb owner appdb;
@@ -34,8 +34,8 @@
     command: >
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
-        -- create the user
-        CREATE ROLE basdb WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
+        -- create user basdb
+        CREATE USER basdb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create the database:
         CREATE DATABASE basdb WITH OWNER basdb ENCODING 'UTF8';

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bas.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bas.yml
@@ -18,8 +18,8 @@
         -- create user appdb
         CREATE USER appdb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database appdb
-        create database appdb owner appdb;
+        -- create database appdb -- default template tablespace
+        CREATE DATABASE appdb OWNER appdb TEMPLATE template0 ENCODING UTF8;
       EOF"
   register: command_status
 
@@ -34,8 +34,8 @@
         -- create user basdb
         CREATE USER basdb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create the database:
-        CREATE DATABASE basdb WITH OWNER basdb ENCODING 'UTF8';
+        -- create database basdb -- default template tablespace
+        CREATE DATABASE basdb OWNER basdb TEMPLATE template0 ENCODING UTF8;
 
         -- Connect to your database and create schema
         \c basdb;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bawaut.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bawaut.yml
@@ -25,7 +25,7 @@
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
         -- create user bawdocs
-        CREATE ROLE bawdocs WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
+        CREATE USER bawdocs WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database bawdocs
         create database bawdocs owner bawdocs template template0 encoding UTF8 ;
@@ -57,7 +57,7 @@
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
         -- create user bawtos
-        CREATE ROLE bawtos WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
+        CREATE USER bawtos WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database bawtos
         create database bawtos owner bawtos template template0 encoding UTF8 ;
@@ -89,7 +89,7 @@
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
         -- create user bawdos
-        CREATE ROLE bawdos WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
+        CREATE USER bawdos WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database bawdos
         create database bawdos owner bawdos template template0 encoding UTF8 ;
@@ -122,7 +122,7 @@
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
         -- create user chdb
-        CREATE ROLE chdb WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
+        CREATE USER chdb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database chdb
         create database chdb owner chdb template template0 encoding UTF8 ;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bawaut.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bawaut.yml
@@ -27,12 +27,11 @@
         -- create user bawdocs
         CREATE USER bawdocs WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database bawdocs
-        create database bawdocs owner bawdocs template template0 encoding UTF8 ;
-        revoke connect on database bawdocs from public;
+        -- create tablespace for bawdocs
+        CREATE TABLESPACE bawdocs_tbs OWNER bawdocs LOCATION '/bitnami/postgresql/tablespaces/bawdocs';
 
-        -- please modify location follow your requirement
-        create tablespace bawdocs_tbs owner bawdocs location '/bitnami/postgresql/tablespaces/bawdocs';
+        -- create database bawdocs
+        CREATE DATABASE bawdocs OWNER bawdocs TEMPLATE template0 ENCODING UTF8 TABLESPACE bawdocs_tbs;
       EOF"
   register: command_status
 
@@ -56,12 +55,11 @@
         -- create user bawtos
         CREATE USER bawtos WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database bawtos
-        create database bawtos owner bawtos template template0 encoding UTF8 ;
-        revoke connect on database bawtos from public;
+        -- create tablespace for bawtos
+        CREATE TABLESPACE bawtos_tbs OWNER bawtos LOCATION '/bitnami/postgresql/tablespaces/bawtos';
 
-        -- please modify location follow your requirement
-        create tablespace bawtos_tbs owner bawtos location '/bitnami/postgresql/tablespaces/bawtos';
+        -- create database bawtos
+        CREATE DATABASE bawtos OWNER bawtos TEMPLATE template0 ENCODING UTF8 TABLESPACE bawtos_tbs;
       EOF"
   register: command_status
 
@@ -85,12 +83,11 @@
         -- create user bawdos
         CREATE USER bawdos WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database bawdos
-        create database bawdos owner bawdos template template0 encoding UTF8 ;
-        revoke connect on database bawdos from public;
+        -- create tablespace for bawdos
+        CREATE TABLESPACE bawdos_tbs OWNER bawdos LOCATION '/bitnami/postgresql/tablespaces/bawdos';
 
-        -- please modify location follow your requirement
-        create tablespace bawdos_tbs owner bawdos location '/bitnami/postgresql/tablespaces/bawdos';
+        -- create database bawdos
+        CREATE DATABASE bawdos OWNER bawdos TEMPLATE template0 ENCODING UTF8 TABLESPACE bawdos_tbs;
       EOF"
   register: command_status
 
@@ -115,12 +112,11 @@
         -- create user chdb
         CREATE USER chdb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database chdb
-        create database chdb owner chdb template template0 encoding UTF8 ;
-        revoke connect on database chdb from public;
+        -- create tablespace for chdb
+        CREATE TABLESPACE chdb_tbs OWNER chdb LOCATION '/bitnami/postgresql/tablespaces/chdb';
 
-        -- please modify location follow your requirement
-        create tablespace chdb_tbs owner chdb location '/bitnami/postgresql/tablespaces/chdb';
+        -- create database chdb
+        CREATE DATABASE chdb OWNER chdb TEMPLATE template0 ENCODING UTF8 TABLESPACE chdb_tbs;
       EOF"
   register: command_status
 
@@ -149,7 +145,7 @@
 
         -- create database bawexternal
         CREATE DATABASE bawexternal OWNER bawexternal TEMPLATE template0 ENCODING UTF8 TABLESPACE bawexternal_tbs;
-        REVOKE CONNECT ON DATABASE bawexternal FROM public;
+        REVOKE CONNECT ON DATABASE bawexternal FROM PUBLIC;
 
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bawaut.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bawaut.yml
@@ -32,6 +32,7 @@
 
         -- create database bawdocs
         CREATE DATABASE bawdocs OWNER bawdocs TEMPLATE template0 ENCODING UTF8 TABLESPACE bawdocs_tbs;
+        REVOKE CONNECT ON DATABASE bawdocs FROM PUBLIC;
       EOF"
   register: command_status
 
@@ -60,6 +61,7 @@
 
         -- create database bawtos
         CREATE DATABASE bawtos OWNER bawtos TEMPLATE template0 ENCODING UTF8 TABLESPACE bawtos_tbs;
+        REVOKE CONNECT ON DATABASE bawtos FROM PUBLIC;
       EOF"
   register: command_status
 
@@ -88,6 +90,7 @@
 
         -- create database bawdos
         CREATE DATABASE bawdos OWNER bawdos TEMPLATE template0 ENCODING UTF8 TABLESPACE bawdos_tbs;
+        REVOKE CONNECT ON DATABASE bawdos FROM PUBLIC;
       EOF"
   register: command_status
 
@@ -117,6 +120,7 @@
 
         -- create database chdb
         CREATE DATABASE chdb OWNER chdb TEMPLATE template0 ENCODING UTF8 TABLESPACE chdb_tbs;
+        REVOKE CONNECT ON DATABASE chdb FROM PUBLIC;
       EOF"
   register: command_status
 

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bawaut.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bawaut.yml
@@ -30,12 +30,9 @@
         -- create database bawdocs
         create database bawdocs owner bawdocs template template0 encoding UTF8 ;
         revoke connect on database bawdocs from public;
-        grant all privileges on database bawdocs to bawdocs;
-        grant connect, temp, create on database bawdocs to bawdocs;
 
         -- please modify location follow your requirement
         create tablespace bawdocs_tbs owner bawdocs location '/bitnami/postgresql/tablespaces/bawdocs';
-        grant create on tablespace bawdocs_tbs to bawdocs;
       EOF"
   register: command_status
 
@@ -62,12 +59,9 @@
         -- create database bawtos
         create database bawtos owner bawtos template template0 encoding UTF8 ;
         revoke connect on database bawtos from public;
-        grant all privileges on database bawtos to bawtos;
-        grant connect, temp, create on database bawtos to bawtos;
 
         -- please modify location follow your requirement
         create tablespace bawtos_tbs owner bawtos location '/bitnami/postgresql/tablespaces/bawtos';
-        grant create on tablespace bawtos_tbs to bawtos;
       EOF"
   register: command_status
 
@@ -94,12 +88,9 @@
         -- create database bawdos
         create database bawdos owner bawdos template template0 encoding UTF8 ;
         revoke connect on database bawdos from public;
-        grant all privileges on database bawdos to bawdos;
-        grant connect, temp, create on database bawdos to bawdos;
 
         -- please modify location follow your requirement
         create tablespace bawdos_tbs owner bawdos location '/bitnami/postgresql/tablespaces/bawdos';
-        grant create on tablespace bawdos_tbs to bawdos;
       EOF"
   register: command_status
 
@@ -127,12 +118,9 @@
         -- create database chdb
         create database chdb owner chdb template template0 encoding UTF8 ;
         revoke connect on database chdb from public;
-        grant all privileges on database chdb to chdb;
-        grant connect, temp, create on database chdb to chdb;
 
         -- please modify location follow your requirement
         create tablespace chdb_tbs owner chdb location '/bitnami/postgresql/tablespaces/chdb';
-        grant create on tablespace chdb_tbs to chdb;
       EOF"
   register: command_status
 

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bawaut.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bawaut.yml
@@ -146,7 +146,6 @@
         -- create database bawexternal
         CREATE DATABASE bawexternal OWNER bawexternal TEMPLATE template0 ENCODING UTF8 TABLESPACE bawexternal_tbs;
         REVOKE CONNECT ON DATABASE bawexternal FROM PUBLIC;
-
       EOF"
   register: command_status
 

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bawaut.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bawaut.yml
@@ -13,7 +13,7 @@
   kubernetes.core.k8s_exec:
     namespace: "{{ cp4ba_postgresql_project }}"
     pod: "{{ postgresql_pod.resources[0].metadata.name }}"
-    command: mkdir -p /bitnami/postgresql/tablespaces/bawdocs
+    command: mkdir -p /bitnami/postgresql/tablespaces/bawdocs_tbs
   register: command_status
   failed_when: command_status.rc != 0 and command_status.stderr is not search('.*File exists.*')
 
@@ -42,7 +42,7 @@
   kubernetes.core.k8s_exec:
     namespace: "{{ cp4ba_postgresql_project }}"
     pod: "{{ postgresql_pod.resources[0].metadata.name }}"
-    command: mkdir -p /bitnami/postgresql/tablespaces/bawtos
+    command: mkdir -p /bitnami/postgresql/tablespaces/bawtos_tbs
   register: command_status
   failed_when: command_status.rc != 0 and command_status.stderr is not search('.*File exists.*')
 
@@ -71,7 +71,7 @@
   kubernetes.core.k8s_exec:
     namespace: "{{ cp4ba_postgresql_project }}"
     pod: "{{ postgresql_pod.resources[0].metadata.name }}"
-    command: mkdir -p /bitnami/postgresql/tablespaces/bawdos
+    command: mkdir -p /bitnami/postgresql/tablespaces/bawdos_tbs
   register: command_status
   failed_when: command_status.rc != 0 and command_status.stderr is not search('.*File exists.*')
 
@@ -101,7 +101,7 @@
   kubernetes.core.k8s_exec:
     namespace: "{{ cp4ba_postgresql_project }}"
     pod: "{{ postgresql_pod.resources[0].metadata.name }}"
-    command: mkdir -p /bitnami/postgresql/tablespaces/chdb
+    command: mkdir -p /bitnami/postgresql/tablespaces/chdb_tbs
   register: command_status
   failed_when: command_status.rc != 0 and command_status.stderr is not search('.*File exists.*')
 
@@ -129,7 +129,7 @@
   kubernetes.core.k8s_exec:
     namespace: "{{ cp4ba_postgresql_project }}"
     pod: "{{ postgresql_pod.resources[0].metadata.name }}"
-    command: mkdir -p /bitnami/postgresql/tablespaces/bawexternal
+    command: mkdir -p /bitnami/postgresql/tablespaces/bawexternal_tbs
   register: command_status
   failed_when: command_status.rc != 0 and command_status.stderr is not search('.*File exists.*')
 

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bawaut.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/bawaut.yml
@@ -28,7 +28,7 @@
         CREATE USER bawdocs WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create tablespace for bawdocs
-        CREATE TABLESPACE bawdocs_tbs OWNER bawdocs LOCATION '/bitnami/postgresql/tablespaces/bawdocs';
+        CREATE TABLESPACE bawdocs_tbs OWNER bawdocs LOCATION '/bitnami/postgresql/tablespaces/bawdocs_tbs';
 
         -- create database bawdocs
         CREATE DATABASE bawdocs OWNER bawdocs TEMPLATE template0 ENCODING UTF8 TABLESPACE bawdocs_tbs;
@@ -57,7 +57,7 @@
         CREATE USER bawtos WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create tablespace for bawtos
-        CREATE TABLESPACE bawtos_tbs OWNER bawtos LOCATION '/bitnami/postgresql/tablespaces/bawtos';
+        CREATE TABLESPACE bawtos_tbs OWNER bawtos LOCATION '/bitnami/postgresql/tablespaces/bawtos_tbs';
 
         -- create database bawtos
         CREATE DATABASE bawtos OWNER bawtos TEMPLATE template0 ENCODING UTF8 TABLESPACE bawtos_tbs;
@@ -86,7 +86,7 @@
         CREATE USER bawdos WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create tablespace for bawdos
-        CREATE TABLESPACE bawdos_tbs OWNER bawdos LOCATION '/bitnami/postgresql/tablespaces/bawdos';
+        CREATE TABLESPACE bawdos_tbs OWNER bawdos LOCATION '/bitnami/postgresql/tablespaces/bawdos_tbs';
 
         -- create database bawdos
         CREATE DATABASE bawdos OWNER bawdos TEMPLATE template0 ENCODING UTF8 TABLESPACE bawdos_tbs;
@@ -116,7 +116,7 @@
         CREATE USER chdb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create tablespace for chdb
-        CREATE TABLESPACE chdb_tbs OWNER chdb LOCATION '/bitnami/postgresql/tablespaces/chdb';
+        CREATE TABLESPACE chdb_tbs OWNER chdb LOCATION '/bitnami/postgresql/tablespaces/chdb_tbs';
 
         -- create database chdb
         CREATE DATABASE chdb OWNER chdb TEMPLATE template0 ENCODING UTF8 TABLESPACE chdb_tbs;
@@ -145,7 +145,7 @@
         CREATE USER bawexternal WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create tablespace for bawexternal
-        CREATE TABLESPACE bawexternal_tbs OWNER bawexternal LOCATION '/bitnami/postgresql/tablespaces/bawexternal';
+        CREATE TABLESPACE bawexternal_tbs OWNER bawexternal LOCATION '/bitnami/postgresql/tablespaces/bawexternal_tbs';
 
         -- create database bawexternal
         CREATE DATABASE bawexternal OWNER bawexternal TEMPLATE template0 ENCODING UTF8 TABLESPACE bawexternal_tbs;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/fncm.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/fncm.yml
@@ -30,12 +30,9 @@
         -- create database gcddb
         create database gcddb owner gcddb template template0 encoding UTF8 ;
         revoke connect on database gcddb from public;
-        grant all privileges on database gcddb to gcddb;
-        grant connect, temp, create on database gcddb to gcddb;
 
         -- please modify location follow your requirement
         create tablespace gcddb_tbs owner gcddb location '/bitnami/postgresql/tablespaces/gcddb';
-        grant create on tablespace gcddb_tbs to gcddb;
       EOF"
   register: command_status
 
@@ -62,11 +59,8 @@
         -- create database os1db
         create database os1db owner os1db template template0 encoding UTF8 ;
         revoke connect on database os1db from public;
-        grant all privileges on database os1db to os1db;
-        grant connect, temp, create on database os1db to os1db;
 
         -- please modify location follow your requirement
         create tablespace os1db_tbs owner os1db location '/bitnami/postgresql/tablespaces/os1db';
-        grant create on tablespace os1db_tbs to os1db;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/fncm.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/fncm.yml
@@ -32,6 +32,7 @@
 
         -- create database gcddb
         CREATE DATABASE gcddb OWNER gcddb TEMPLATE template0 ENCODING UTF8 TABLESPACE gcddb_tbs;
+        REVOKE CONNECT ON DATABASE gcddb FROM PUBLIC;
       EOF"
   register: command_status
 
@@ -60,5 +61,6 @@
 
         -- create database os1db
         CREATE DATABASE os1db OWNER os1db TEMPLATE template0 ENCODING UTF8 TABLESPACE os1db_tbs;
+        REVOKE CONNECT ON DATABASE os1db FROM PUBLIC;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/fncm.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/fncm.yml
@@ -13,7 +13,7 @@
   kubernetes.core.k8s_exec:
     namespace: "{{ cp4ba_postgresql_project }}"
     pod: "{{ postgresql_pod.resources[0].metadata.name }}"
-    command: mkdir -p /bitnami/postgresql/tablespaces/gcddb
+    command: mkdir -p /bitnami/postgresql/tablespaces/gcddb_tbs
   register: command_status
   failed_when: command_status.rc != 0 and command_status.stderr is not search('.*File exists.*')
 
@@ -42,7 +42,7 @@
   kubernetes.core.k8s_exec:
     namespace: "{{ cp4ba_postgresql_project }}"
     pod: "{{ postgresql_pod.resources[0].metadata.name }}"
-    command: mkdir -p /bitnami/postgresql/tablespaces/os1db
+    command: mkdir -p /bitnami/postgresql/tablespaces/os1db_tbs
   register: command_status
   failed_when: command_status.rc != 0 and command_status.stderr is not search('.*File exists.*')
 

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/fncm.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/fncm.yml
@@ -25,7 +25,7 @@
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
         -- create user gcddb
-        CREATE ROLE gcddb WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
+        CREATE USER gcddb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database gcddb
         create database gcddb owner gcddb template template0 encoding UTF8 ;
@@ -57,7 +57,7 @@
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
         -- create user os1db
-        CREATE ROLE os1db WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
+        CREATE USER os1db WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database os1db
         create database os1db owner os1db template template0 encoding UTF8 ;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/fncm.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/fncm.yml
@@ -28,7 +28,7 @@
         CREATE USER gcddb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create tablespace for gcddb
-        CREATE TABLESPACE gcddb_tbs OWNER gcddb LOCATION '/bitnami/postgresql/tablespaces/gcddb';
+        CREATE TABLESPACE gcddb_tbs OWNER gcddb LOCATION '/bitnami/postgresql/tablespaces/gcddb_tbs';
 
         -- create database gcddb
         CREATE DATABASE gcddb OWNER gcddb TEMPLATE template0 ENCODING UTF8 TABLESPACE gcddb_tbs;
@@ -57,7 +57,7 @@
         CREATE USER os1db WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create tablespace for os1db
-        CREATE TABLESPACE os1db_tbs OWNER os1db LOCATION '/bitnami/postgresql/tablespaces/os1db';
+        CREATE TABLESPACE os1db_tbs OWNER os1db LOCATION '/bitnami/postgresql/tablespaces/os1db_tbs';
 
         -- create database os1db
         CREATE DATABASE os1db OWNER os1db TEMPLATE template0 ENCODING UTF8 TABLESPACE os1db_tbs;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/fncm.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/fncm.yml
@@ -27,12 +27,11 @@
         -- create user gcddb
         CREATE USER gcddb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database gcddb
-        create database gcddb owner gcddb template template0 encoding UTF8 ;
-        revoke connect on database gcddb from public;
+        -- create tablespace for gcddb
+        CREATE TABLESPACE gcddb_tbs OWNER gcddb LOCATION '/bitnami/postgresql/tablespaces/gcddb';
 
-        -- please modify location follow your requirement
-        create tablespace gcddb_tbs owner gcddb location '/bitnami/postgresql/tablespaces/gcddb';
+        -- create database gcddb
+        CREATE DATABASE gcddb OWNER gcddb TEMPLATE template0 ENCODING UTF8 TABLESPACE gcddb_tbs;
       EOF"
   register: command_status
 
@@ -56,11 +55,10 @@
         -- create user os1db
         CREATE USER os1db WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database os1db
-        create database os1db owner os1db template template0 encoding UTF8 ;
-        revoke connect on database os1db from public;
+        -- create tablespace for os1db
+        CREATE TABLESPACE os1db_tbs OWNER os1db LOCATION '/bitnami/postgresql/tablespaces/os1db';
 
-        -- please modify location follow your requirement
-        create tablespace os1db_tbs owner os1db location '/bitnami/postgresql/tablespaces/os1db';
+        -- create database os1db
+        CREATE DATABASE os1db OWNER os1db TEMPLATE template0 ENCODING UTF8 TABLESPACE os1db_tbs;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ier.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ier.yml
@@ -28,7 +28,7 @@
 
 
         -- create tablespace for fpos
-        CREATE TABLESPACE fpos_tbs OWNER fpos LOCATION '/bitnami/postgresql/tablespaces/fpos';
+        CREATE TABLESPACE fpos_tbs OWNER fpos LOCATION '/bitnami/postgresql/tablespaces/fpos_tbs';
 
         -- create database fpos
         CREATE DATABASE fpos OWNER fpos TEMPLATE template0 ENCODING UTF8 TABLESPACE fpos_tbs;
@@ -56,7 +56,7 @@
         CREATE USER ros WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create tablespace for ros
-        CREATE TABLESPACE ros_tbs OWNER ros LOCATION '/bitnami/postgresql/tablespaces/ros';
+        CREATE TABLESPACE ros_tbs OWNER ros LOCATION '/bitnami/postgresql/tablespaces/ros_tbs';
 
         -- create database ros
         CREATE DATABASE ros OWNER ros TEMPLATE template0 ENCODING UTF8 TABLESPACE ros_tbs;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ier.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ier.yml
@@ -12,7 +12,7 @@
   kubernetes.core.k8s_exec:
     namespace: "{{ cp4ba_postgresql_project }}"
     pod: "{{ postgresql_pod.resources[0].metadata.name }}"
-    command: mkdir -p /bitnami/postgresql/tablespaces/fpos
+    command: mkdir -p /bitnami/postgresql/tablespaces/fpos_tbs
   register: command_status
   failed_when: command_status.rc != 0 and command_status.stderr is not search('.*File exists.*')
 
@@ -41,7 +41,7 @@
   kubernetes.core.k8s_exec:
     namespace: "{{ cp4ba_postgresql_project }}"
     pod: "{{ postgresql_pod.resources[0].metadata.name }}"
-    command: mkdir -p /bitnami/postgresql/tablespaces/ros
+    command: mkdir -p /bitnami/postgresql/tablespaces/ros_tbs
   register: command_status
   failed_when: command_status.rc != 0 and command_status.stderr is not search('.*File exists.*')
 

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ier.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ier.yml
@@ -24,7 +24,7 @@
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
         -- create user fpos
-        CREATE ROLE fpos WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
+        CREATE USER fpos WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database fpos
         create database fpos owner fpos template template0 encoding UTF8 ;
@@ -55,7 +55,7 @@
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
         -- create user ros
-        CREATE ROLE ros WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
+        CREATE USER ros WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database ros
         create database ros owner ros template template0 encoding UTF8 ;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ier.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ier.yml
@@ -29,12 +29,9 @@
         -- create database fpos
         create database fpos owner fpos template template0 encoding UTF8 ;
         revoke connect on database fpos from public;
-        grant all privileges on database fpos to fpos;
-        grant connect, temp, create on database fpos to fpos;
 
         -- please modify location follow your requirement
         create tablespace fpos_tbs owner fpos location '/bitnami/postgresql/tablespaces/fpos';
-        grant create on tablespace fpos_tbs to fpos;
       EOF"
   register: command_status
 
@@ -60,11 +57,8 @@
         -- create database ros
         create database ros owner ros template template0 encoding UTF8 ;
         revoke connect on database ros from public;
-        grant all privileges on database ros to ros;
-        grant connect, temp, create on database ros to ros;
 
         -- please modify location follow your requirement
         create tablespace ros_tbs owner ros location '/bitnami/postgresql/tablespaces/ros';
-        grant create on tablespace ros_tbs to ros;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ier.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ier.yml
@@ -26,12 +26,12 @@
         -- create user fpos
         CREATE USER fpos WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database fpos
-        create database fpos owner fpos template template0 encoding UTF8 ;
-        revoke connect on database fpos from public;
 
-        -- please modify location follow your requirement
-        create tablespace fpos_tbs owner fpos location '/bitnami/postgresql/tablespaces/fpos';
+        -- create tablespace for fpos
+        CREATE TABLESPACE fpos_tbs OWNER fpos LOCATION '/bitnami/postgresql/tablespaces/fpos';
+
+        -- create database fpos
+        CREATE DATABASE fpos OWNER fpos TEMPLATE template0 ENCODING UTF8 TABLESPACE fpos_tbs;
       EOF"
   register: command_status
 
@@ -54,11 +54,10 @@
         -- create user ros
         CREATE USER ros WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database ros
-        create database ros owner ros template template0 encoding UTF8 ;
-        revoke connect on database ros from public;
+        -- create tablespace for ros
+        CREATE TABLESPACE ros_tbs OWNER ros LOCATION '/bitnami/postgresql/tablespaces/ros';
 
-        -- please modify location follow your requirement
-        create tablespace ros_tbs owner ros location '/bitnami/postgresql/tablespaces/ros';
+        -- create database ros
+        CREATE DATABASE ros OWNER ros TEMPLATE template0 ENCODING UTF8 TABLESPACE ros_tbs;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ier.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/ier.yml
@@ -32,6 +32,7 @@
 
         -- create database fpos
         CREATE DATABASE fpos OWNER fpos TEMPLATE template0 ENCODING UTF8 TABLESPACE fpos_tbs;
+        REVOKE CONNECT ON DATABASE fpos FROM PUBLIC;
       EOF"
   register: command_status
 
@@ -59,5 +60,6 @@
 
         -- create database ros
         CREATE DATABASE ros OWNER ros TEMPLATE template0 ENCODING UTF8 TABLESPACE ros_tbs;
+        REVOKE CONNECT ON DATABASE ros FROM PUBLIC;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/odm.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/odm.yml
@@ -22,6 +22,6 @@
 
         -- create database odmdb -- default template tablespace
         CREATE DATABASE odmdb OWNER odmdb TEMPLATE template0 ENCODING UTF8;
-        revoke connect on database odmdb from public;
+        REVOKE CONNECT ON DATABASE odmdb FROM PUBLIC;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/odm.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/odm.yml
@@ -20,8 +20,8 @@
         -- create user odmdb
         CREATE USER odmdb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
-        -- create database odmdb
-        create database odmdb owner odmdb template template0 encoding UTF8 ;
+        -- create database odmdb -- default template tablespace
+        CREATE DATABASE odmdb OWNER odmdb TEMPLATE template0 ENCODING UTF8;
         revoke connect on database odmdb from public;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/odm.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/odm.yml
@@ -23,7 +23,5 @@
         -- create database odmdb
         create database odmdb owner odmdb template template0 encoding UTF8 ;
         revoke connect on database odmdb from public;
-        grant all privileges on database odmdb to odmdb;
-        grant connect, temp, create on database odmdb to odmdb;
       EOF"
   register: command_status

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/odm.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/db/odm.yml
@@ -18,7 +18,7 @@
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
         -- create user odmdb
-        CREATE ROLE odmdb WITH INHERIT LOGIN ENCRYPTED PASSWORD '{{ cp4ba_postgresql_universal_password }}';
+        CREATE USER odmdb WITH PASSWORD '{{ cp4ba_postgresql_universal_password }}';
 
         -- create database odmdb
         create database odmdb owner odmdb template template0 encoding UTF8 ;

--- a/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/remove.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/cp4ba-core/tasks/remove.yml
@@ -325,7 +325,7 @@
     - proj5
     - proj6
 
-- name: Remove PostgreSQL tablespaces
+- name: Remove PostgreSQL tablespace and folder
   ansible.builtin.include_role:
     name: common
     tasks_from: remove-postgresql-tablespace
@@ -333,18 +333,18 @@
     common_postgresql_tablespace_name: "{{ item }}"
     common_postgresql_project: "{{ cp4ba_postgresql_project }}"
   with_items:
-    - aeos
-    - devos1
-    - icndb
-    - bawdocs
-    - bawtos
-    - bawdos
-    - chdb
-    - bawexternal
-    - gcddb
-    - os1db
-    - fpos
-    - ros
+    - aeos_tbs
+    - devos1_tbs
+    - icndb_tbs
+    - bawdocs_tbs
+    - bawtos_tbs
+    - bawdos_tbs
+    - chdb_tbs
+    - bawexternal_tbs
+    - gcddb_tbs
+    - os1db_tbs
+    - fpos_tbs
+    - ros_tbs
 
 - name: Remove PostgreSQL users
   ansible.builtin.include_role:

--- a/automation-roles/50-install-cloud-pak/cp4ba/pm/tasks/install.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/pm/tasks/install.yml
@@ -19,6 +19,7 @@
 
         -- create database pm -- default template tablespace
         CREATE DATABASE pm OWNER pm TEMPLATE template0 ENCODING UTF8;
+        REVOKE CONNECT ON DATABASE pm FROM PUBLIC;
       EOF"
   register: command_status
 

--- a/automation-roles/50-install-cloud-pak/cp4ba/pm/tasks/install.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/pm/tasks/install.yml
@@ -17,8 +17,8 @@
         -- create user pm
         CREATE USER pm WITH PASSWORD '{{ pm_postgresql_password }}';
 
-        -- create database pm
-        create database pm owner pm;
+        -- create database pm -- default template tablespace
+        CREATE DATABASE pm OWNER pm TEMPLATE template0 ENCODING UTF8;
       EOF"
   register: command_status
 

--- a/automation-roles/50-install-cloud-pak/cp4ba/pm/tasks/install.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/pm/tasks/install.yml
@@ -19,9 +19,6 @@
 
         -- create database pm
         create database pm owner pm;
-
-        -- The following grant is used for databases
-        grant all privileges on database pm to pm;
       EOF"
   register: command_status
 

--- a/automation-roles/50-install-cloud-pak/cp4ba/pm/tasks/install.yml
+++ b/automation-roles/50-install-cloud-pak/cp4ba/pm/tasks/install.yml
@@ -14,10 +14,10 @@
     command: >
       bash -c "
         psql postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432 <<-EOF
-        -- create a new user
-        create user pm with password '{{ pm_postgresql_password }}';
+        -- create user pm
+        CREATE USER pm WITH PASSWORD '{{ pm_postgresql_password }}';
 
-        -- create database aaedb
+        -- create database pm
         create database pm owner pm;
 
         -- The following grant is used for databases


### PR DESCRIPTION
Hello again cpd team!

As I was working on PR #826 , I noticed a lot of possible improvements in the scripts creating the Postgres DB.
Here are my submissions ; I think this should improve the global readability of the ansible scripts.

I also have a question about a part of the scripts, cf. to [this other question](#this-other-question) at end of this PR description.

## TL;DR

This patch fix multiple discrepancies between some identical pg SQL snippets, some incoherence/useless code and simplify the global readability of those scrips (in my opinion — Feel free to debate with me on this! 😄 )

## List of Changes

- 57d7142eb7820c0fc24283ecd21fa84656552b40 : Remove a duplicated ansible script for creating the DB proj2 for ADP 
- 972a60aa9a0ad838ee2eeffcf3da12569e127e7f : Replace all SQL`CREATE ROLE` with the simpler `CREATE USER` that has better intent on the expected usage for this `ROLE`
- b1c47daee2f2105df4842f47b1e43646ac312d97 : Remove some unnecessary `GRANT` as the database/tablespace OWNERs already have those permission
- f992230ab54a80c7b59e2a23a94660723c559dd3 : Fix some `CREATE TABLESPACE` not used during database creation
- 8d706c2fbcdccfcabe005ccf6c2a16f5849bc095 : Normalize other database scripts using default tablespace 
- bf4b9dc4b612888747d5a95bc3c4ed02729ca1fc : Remove unnecessary `AUTHORIZATION` for `basdb` users owning the created schema
- 10edbf72b7157a4daeb3db69ab93f5db93b95a9f : Revoke all connection rights on databases for `public` users.
- 6cc0884e8deea668f534e08180f30c98f96ad9f1 : (NEW) Modify tablespace folder names and associated create/delete roles to improve readability


I'm waiting for your feedback! 😄 