### PR TITLE
change embedding model names

### DIFF
--- a/sample-configurations/sample-dynamic/config-samples/cp4d-510.yaml
+++ b/sample-configurations/sample-dynamic/config-samples/cp4d-510.yaml
@@ -365,9 +365,9 @@ cp4d:
       state: removed
     - model_id: multilingual-e5-large
       state: removed
-    - model_id: slate-30m-english-rtrvr-v2
+    - model_id: ibm-slate-30m-english-rtrvr
       state: removed
-    - model_id: slate-125m-english-rtrvr-v2
+    - model_id: ibm-slate-125m-english-rtrvr
       state: removed
       
   - name: watsonx_data


### PR DESCRIPTION
Noticed that the [slate embedding model names](https://github.com/IBM/cloud-pak-deployer/blob/af70f9cd0caa6665859634f055396de8dc87b5c3/sample-configurations/sample-dynamic/config-samples/cp4d-510.yaml#L368-L371) didn't match their values from the [documentation](https://www.ibm.com/docs/en/software-hub/5.1.x?topic=install-foundation-models)

slate-30m-english-rtrvr-v2
slate-125m-english-rtrvr-v2

vs

ibm-slate-30m-english-rtrvr
ibm-slate-125m-english-rtrvr

Is this an error?