### PR TITLE
remove 23.1 rt and update doc

### DIFF
--- a/docs/src/10-use-deployer/3-run/existing-openshift-console.md
+++ b/docs/src/10-use-deployer/3-run/existing-openshift-console.md
@@ -437,9 +437,9 @@ data:
           state: removed
         - model_id: multilingual-e5-large
           state: removed
-        - model_id: slate-30m-english-rtrvr-v2
+        - model_id: ibm-slate-30m-english-rtrvr
           state: removed
-        - model_id: slate-125m-english-rtrvr-v2
+        - model_id: ibm-slate-125m-english-rtrvr
           state: removed
 
       - name: watsonx_data
@@ -520,11 +520,8 @@ data:
         description: Watson Studio Runtimes
         runtimes:
         - ibm-cpd-ws-runtime-241-py
-        - ibm-cpd-ws-runtime-231-py
         - ibm-cpd-ws-runtime-241-pygpu
-        - ibm-cpd-ws-runtime-231-pygpu
         - ibm-cpd-ws-runtime-241-r
-        - ibm-cpd-ws-runtime-231-r
         state: removed 
 ```
 

--- a/sample-configurations/sample-dynamic/config-samples/cp4d-510.yaml
+++ b/sample-configurations/sample-dynamic/config-samples/cp4d-510.yaml
@@ -448,11 +448,8 @@ cp4d:
     description: Watson Studio Runtimes
     runtimes:
     - ibm-cpd-ws-runtime-241-py
-    - ibm-cpd-ws-runtime-231-py
     - ibm-cpd-ws-runtime-241-pygpu
-    - ibm-cpd-ws-runtime-231-pygpu
     - ibm-cpd-ws-runtime-241-r
-    - ibm-cpd-ws-runtime-231-r
     state: removed 
 
 #


### PR DESCRIPTION
[This potentially solves issue 880.](https://github.com/IBM/cloud-pak-deployer/issues/880)

I think that 5.1.0 doesn't support the 23.1 runtime anymore as it fails to install with any of them listed in the config map.

This PR removes them and also updates the doc file with the recent 5.1.0 config changes.