### PR TITLE
Fixed syntax error for when condition

### DIFF
--- a/automation-roles/50-install-cloud-pak/cpfs/cp-ocp-icsp/tasks/create-idms.yml
+++ b/automation-roles/50-install-cloud-pak/cpfs/cp-ocp-icsp/tasks/create-idms.yml
@@ -40,7 +40,7 @@
       _p_command: |
         oc patch image.config.openshift.io/cluster --type=json \
           --patch '[{"op": "add", "path": "/spec/registrySources/insecureRegistries/-", "value": "{{ private_registry_url }}" }]'
-     when: not private_registry_url in _private_registry_entries.stdout
+    when: not private_registry_url in _private_registry_entries.stdout
   when: (current_image_registry.registry_insecure | default(False) | bool)
 
 # Handle registry with CA bundle


### PR DESCRIPTION
The when condition had on space too many which resulted in a parsing error when running the deployer