### PR TITLE
TEKTON pipelines

### DIFF
--- a/automation-roles/50-install-cloud-pak/cp4d/cp4d-variables/tasks/main.yml
+++ b/automation-roles/50-install-cloud-pak/cp4d/cp4d-variables/tasks/main.yml
@@ -161,6 +161,33 @@
 - debug:
     var: _apply_cartridges
 
+# Detect if Watson Studio Pipelines is part of this deployment so we can guard against Tekton conflicts
+- set_fact:
+    _ws_pipelines_requested: "{{ 'ws_pipelines' in (_apply_cartridges | map(attribute='olm_utils_name') | list) }}"
+
+- block:
+  - name: Check if OpenShift Pipelines (Tekton) is installed
+    command: oc get tektonconfig -o json
+    register: _tektonconfig_query
+    changed_when: False
+    failed_when: False
+
+  - set_fact:
+      _tektonconfig_items_count: "{{ (_tektonconfig_query.stdout | from_json).items | length }}"
+    when:
+    - _tektonconfig_query.rc == 0
+    - (_tektonconfig_query.stdout | length) > 0
+
+  - name: Fail when OpenShift Pipelines is detected
+    fail:
+      msg: >-
+        Watson Studio Pipelines cannot be installed while OpenShift Pipelines (Tekton) is present on the cluster.
+        Remove the OpenShift Pipelines operator (and its TektonConfig resource) before running the deployer.
+        See docs/src/10-use-deployer/3-run/existing-openshift-console.md#techzone-clusters-and-watson-studio-pipelines
+        for step-by-step removal instructions.
+    when: (_tektonconfig_items_count | default(0) | int) > 0
+  when: _ws_pipelines_requested
+
 - set_fact:
     _apply_olm_cartridges_list: >-
       {{ _apply_cartridges

--- a/docs/src/10-use-deployer/3-run/existing-openshift-console.md
+++ b/docs/src/10-use-deployer/3-run/existing-openshift-console.md
@@ -7,6 +7,27 @@ See the deployer in action deploying IBM watsonx.ai on an existing OpenShift clu
 ## Log in to the OpenShift cluster
 Log in as a cluster administrator to be able to run the deployer with the correct permissions.
 
+## TechZone clusters and Watson Studio Pipelines (Pipeline Orchestration)
+
+!!! warning "OpenShift Pipelines must be removed manually"
+    The Watson Studio Pipelines cartridge (also referred to as Pipeline Orchestration) installs its own Tekton controllers.  
+    TechZone OpenShift clusters already include the Red Hat OpenShift Pipelines operator that owns the same Tekton
+    resources, so the install fails if both are present. The Cloud Pak Deployer does **not** uninstall shared cluster
+    components. Remove OpenShift Pipelines yourself **before** you add `ws-pipelines` to the configuration.
+
+Follow these steps once per cluster:
+
+1. Sign in to the OpenShift web console with a cluster-admin user.
+2. Go to `Operators` → `Installed Operators`, open **OpenShift Pipelines** (namespace `openshift-operators`), choose **Actions → Uninstall**, keep *Delete operand resources* selected, and confirm.
+3. Wait until the operator disappears from the list and the `openshift-pipelines-operator` CSV is removed.
+4. Verify that no `TektonConfig` instance is left. The following command should return *No resources found*:
+   ```bash
+   oc get tektonconfig
+   ```
+5. If a `tekton-pipelines` project still exists, delete it to remove the remaining webhooks.
+
+TechZone automation itself runs on OpenShift Pipelines, so uninstalling it stops the TechZone pipeline that would normally start the deployer. After completing the above steps, start the deployer directly from the OpenShift console (as described below). You can reinstall OpenShift Pipelines from OperatorHub again after Watson Studio Pipelines has been successfully deployed.
+
 ## Prepare the deployer project
 * Go to the OpenShift console
 * Click the "+" sign at the top of the page


### PR DESCRIPTION
Extended the existing OpenShift guide with the same Tekton conflict warning now present in the console doc. It’s right after the initial assumptions and explains why Watson Studio Pipelines (Pipeline Orchestration) can’t coexist with OpenShift Pipelines (Tekton)

Added a CLI-focused remediation: oc get tektonconfig to detect the operator, followed by oc delete tektonconfig --all, targeted CSV/subscription deletions, and an optional namespace cleanup so TechZone users can perform the full removal without using the UI. The section ends by instructing users to rerun oc get tektonconfig and to reinstall OpenShift Pipelines later if needed

Added a fail-fast guard in the CP4D cartridge processing flow: when ws-pipelines is still in the final install list we now run oc get tektonconfig -o json and abort with a descriptive message if any TektonConfig objects remain, preventing the Tekton controller conflict from even attempting the install (automation-roles/50-install-cloud-pak/cp4d/cp4d-variables/tasks/main.yml