### PR TITLE
Fix: cp4d - create-dmc-profiles - hard-codes project

### DIFF
--- a/automation-roles/60-configure-cloud-pak/cp4d/cp4d-configure-dmc-profiles/tasks/create-dmc-profiles.yml
+++ b/automation-roles/60-configure-cloud-pak/cp4d/cp4d-configure-dmc-profiles/tasks/create-dmc-profiles.yml
@@ -5,7 +5,7 @@
 
 - name: Retrieve DMC profiles for the instance
   uri:
-    url: 'https://{{ cp4d_url.stdout }}/icp4data-addons/dmc-{{ _dmc_instance.id }}/cpd/dbapi/v4/dbprofiles'
+    url: 'https://{{ cp4d_url.stdout }}/icp4data-addons/dmc-{{ _dmc_instance.id }}/{{ current_cp4d_cluster.project }}/dbapi/v4/dbprofiles'
     method: GET
     headers:
       Content-Type: application/json


### PR DESCRIPTION
In the task “Retrieve DMC profiles for the instance' the project name was hard-coded within the URI for retrieving the DMC profile data. The deployment fails if a different project name is used. 