### PR TITLE
feat: Add Ansible Vault support for secure secret management

### DIFF
--- a/automation-roles/99-generic/vault/vault-connect/tasks/connect-ansible-vault.yml
+++ b/automation-roles/99-generic/vault/vault-connect/tasks/connect-ansible-vault.yml
@@ -1,0 +1,28 @@
+---
+- name: Validate mandatory variables for Ansible Vault
+  assert:
+    that:
+      - vault_password_file is defined
+      - vault_password_file != ''
+    fail_msg: "vault_password_file must be defined for ansible-vault type"
+
+- name: Check if Ansible Vault password file exists
+  stat:
+    path: "{{ vault_password_file }}"
+  register: vault_password_file_stat
+
+- name: Fail if Ansible Vault password file does not exist
+  fail:
+    msg: "Ansible Vault password file {{ vault_password_file }} does not exist"
+  when: not vault_password_file_stat.stat.exists
+
+- name: Validate Ansible Vault password file is readable
+  assert:
+    that:
+      - vault_password_file_stat.stat.readable
+    fail_msg: "Ansible Vault password file {{ vault_password_file }} is not readable"
+
+- name: Successfully connected to Ansible Vault
+  debug:
+    msg: "Successfully validated Ansible Vault password file: {{ vault_password_file }}"
+

--- a/automation-roles/99-generic/vault/vault-connect/tasks/main.yaml
+++ b/automation-roles/99-generic/vault/vault-connect/tasks/main.yaml
@@ -49,7 +49,20 @@
     - name: No login to file fault needed
       debug:
         msg: File vault directory is {{ status_dir }}/vault
-  when: "vault_type == 'file-vault'"  
+  when: "vault_type == 'file-vault'"
+
+- name: Login to Ansible vault
+  block:
+
+    - name: Validate mandatory variables are defined
+      assert:
+        that:
+          - vault_type is defined
+          - vault_authentication_type is defined
+
+    - include_tasks: connect-ansible-vault.yml
+      when: vault_authentication_type == 'password-file'
+  when: "vault_type == 'ansible-vault'"
 
 - set_fact:
     vault_login_success: "true"

--- a/automation-roles/99-generic/vault/vault-connect/vars/main.yaml
+++ b/automation-roles/99-generic/vault/vault-connect/vars/main.yaml
@@ -1,2 +1,2 @@
-supported_vault_types: ['hashicorp-vault','ibmcloud-vault','file-vault']
-supported_vault_authentication_types: ['api-key','certificate','none']
+supported_vault_types: ['hashicorp-vault','ibmcloud-vault','file-vault','ansible-vault']
+supported_vault_authentication_types: ['api-key','certificate','none','password-file']

--- a/automation-roles/99-generic/vault/vault-get-secret/tasks/get-secret-ansible-vault.yml
+++ b/automation-roles/99-generic/vault/vault-get-secret/tasks/get-secret-ansible-vault.yml
@@ -1,0 +1,60 @@
+---
+- name: Get secret Validate mandatory variables are defined
+  assert:
+    that:
+      - secret_group is defined
+      - secret_name is defined
+      - vault_password_file is defined
+
+- name: Fail if a secret field was specified for a vault other than Hashicorp
+  fail:
+    msg: "Secret name {{ secret_name }} can only have a secret field specification for Hashicorp Vault"
+  when: secret_name is search(",")
+
+- name: Check that ansible vault file {{ secret_group }} exists
+  stat:
+    path: "{{ status_dir }}/vault/{{ secret_group }}"
+  register: ansible_vault_file_details
+
+- set_fact:
+    secret_value: ""
+
+- name: Decrypt and retrieve secret from Ansible Vault file
+  block:
+    - name: Create temporary file for decrypted content
+      tempfile:
+        state: file
+        suffix: .decrypted
+      register: temp_decrypted_file
+
+    - name: Decrypt Ansible Vault file
+      command: >
+        ansible-vault decrypt
+        --vault-password-file {{ vault_password_file }}
+        --output {{ temp_decrypted_file.path }}
+        {{ status_dir }}/vault/{{ secret_group }}
+      register: decrypt_result
+      changed_when: false
+
+    - name: Extract secret value from decrypted file
+      shell: >
+        grep -E "^{{ secret_name }}=" {{ temp_decrypted_file.path }} | cut -d "=" -f 2-
+      register: secret_value_result
+      changed_when: false
+
+    - set_fact:
+        secret_value: "{{ secret_value_result.stdout | b64decode }}"
+      when: secret_value_result.stdout != ""
+
+  always:
+    - name: Remove temporary decrypted file
+      file:
+        path: "{{ temp_decrypted_file.path }}"
+        state: absent
+      when: temp_decrypted_file.path is defined
+
+  when: ansible_vault_file_details.stat.exists
+
+- include_tasks: write-secret-to-file.yml
+  when: secret_file | default("") != ''
+

--- a/automation-roles/99-generic/vault/vault-get-secret/tasks/get-secret.yml
+++ b/automation-roles/99-generic/vault/vault-get-secret/tasks/get-secret.yml
@@ -29,6 +29,17 @@
     - include_tasks: get-secret-file.yml
   when: "vault_type == 'file-vault'"
 
+- name: Get Secret from Ansible Vault
+  block:
+    - include_tasks: get-secret-ansible-vault.yml
+  when: "vault_type == 'ansible-vault'"
+  rescue:
+    #Re-connect to vault
+    - include_role:
+        name: vault-connect
+    #Re-attempt the get-secret
+    - include_tasks: get-secret.yml
+
 - name: Set secret variable if specified
   set_fact:
     "{{ _p_secret_variable }}": "{{ secret_value }}"

--- a/automation-roles/99-generic/vault/vault-set-secret/tasks/create-secret-ansible-vault.yml
+++ b/automation-roles/99-generic/vault/vault-set-secret/tasks/create-secret-ansible-vault.yml
@@ -1,0 +1,68 @@
+---
+- name: Create secret Validate mandatory variables are defined
+  assert:
+    that:
+      - secret_group is defined
+      - secret_name is defined
+      - file_secret_payload is defined
+      - vault_password_file is defined
+
+- name: Fail if a secret field was specified for a vault other than Hashicorp
+  fail:
+    msg: "Secret name {{ secret_name }} can only have a secret field specification for Hashicorp Vault"
+  when: secret_name is search(",")
+
+- name: Create directory {{ status_dir }}/vault if not existent
+  file:
+    path: "{{ status_dir }}/vault"
+    state: directory
+
+- name: Check if Ansible Vault file exists
+  stat:
+    path: "{{ status_dir }}/vault/{{ secret_group }}"
+  register: ansible_vault_file_stat
+
+- name: Handle Ansible Vault file creation or update
+  block:
+    - name: Create temporary file for plaintext content
+      tempfile:
+        state: file
+        suffix: .plaintext
+      register: temp_plaintext_file
+
+    - name: Decrypt existing Ansible Vault file if it exists
+      command: >
+        ansible-vault decrypt
+        --vault-password-file {{ vault_password_file }}
+        --output {{ temp_plaintext_file.path }}
+        {{ status_dir }}/vault/{{ secret_group }}
+      when: ansible_vault_file_stat.stat.exists
+      changed_when: false
+
+    - name: Add or replace secret in plaintext file
+      lineinfile:
+        path: "{{ temp_plaintext_file.path }}"
+        regexp: "^{{ secret_name }}="
+        line: "{{ secret_name }}={{ file_secret_payload }}"
+        state: present
+        create: True
+
+    - name: Encrypt plaintext file to Ansible Vault
+      command: >
+        ansible-vault encrypt
+        --vault-password-file {{ vault_password_file }}
+        --output {{ status_dir }}/vault/{{ secret_group }}
+        {{ temp_plaintext_file.path }}
+      changed_when: true
+
+  always:
+    - name: Remove temporary plaintext file
+      file:
+        path: "{{ temp_plaintext_file.path }}"
+        state: absent
+      when: temp_plaintext_file.path is defined
+
+- name: Successfully created secret
+  debug:
+    msg: "Secret {{ secret_name }} successfully created in Ansible Vault file {{ secret_group }}"
+

--- a/automation-roles/99-generic/vault/vault-set-secret/tasks/create-secret.yml
+++ b/automation-roles/99-generic/vault/vault-set-secret/tasks/create-secret.yml
@@ -54,6 +54,20 @@
         file_secret_payload: "{{ secret_value_to_set }}"
   when: "vault_type == 'file-vault'"
 
+- name: Set secret in Ansible Vault
+  block:
+    - include_tasks: create-secret-ansible-vault.yml
+      vars:
+        file_secret_payload: "{{ secret_value_to_set }}"
+  when: "vault_type == 'ansible-vault'"
+  rescue:
+    #Re-connect to vault
+    - include_role:
+        name: vault-connect
+    
+    #Re-attempt the set-secret
+    - include_tasks: create-secret.yml
+
 - name: Secret {{ secret_group }}/{{ secret_name }} was set
   debug:
     msg: ""

--- a/docs/src/30-reference/configuration/vault.md
+++ b/docs/src/30-reference/configuration/vault.md
@@ -7,11 +7,14 @@ Configuration of the vault is done through a `vault` object in the configuration
 
 The following Vault implementations can be used to store and retrieve secrets:
 - File Vault (no encryption)
+- Ansible Vault (encrypted with password)
 - IBM Cloud Secrets Manager
 - Hashicorp Vault (token authentication)
 - Hashicorp Vault (certificate authentication)
 
 The **File Vault** is the default vault and also the simplest. It does not require a password and all secrets are stored in base-64 encoding in a properties file under the `<status_directory>/vault` directory. The name of the vault file is the `environment_name` you specified in the global configuration, inventory file or at the command line.
+
+The **Ansible Vault** provides encryption for secrets using Ansible's built-in vault functionality. Secrets are stored in encrypted files under the `<status_directory>/vault` directory, protected by a password file. This provides a good balance between security and ease of use without requiring external services.
 
 All of the other vault options require some secret manager (IBM Cloud service or Hashicorp Vault) to be available and you need to specify a password or provide a certificate.
 
@@ -26,13 +29,30 @@ vault:
 
 | Property | Description                                                          | Mandatory | Allowed values |
 | -------- | -------------------------------------------------------------------- | --------- | -------------- |
-| vault_type | Chosen implementation of the vault                                 | Yes       | file-vault, ibmcloud-vault, hashicorp-vault |
+| vault_type | Chosen implementation of the vault                                 | Yes       | file-vault, ansible-vault, ibmcloud-vault, hashicorp-vault |
 
 ### Properties for `file-vault`
 
 | Property | Description                                                          | Mandatory | Allowed values |
 | -------- | -------------------------------------------------------------------- | --------- | -------------- |
 | vault_authentication_type | Authentication method for the file vault            | No        | none          |
+
+### Properties for `ansible-vault`
+
+| Property | Description                                                          | Mandatory | Allowed values |
+| -------- | -------------------------------------------------------------------- | --------- | -------------- |
+| vault_authentication_type | Authentication method for ansible vault              | Yes       | password-file |
+| vault_password_file | Path to the file containing the ansible-vault password | Yes       |           |
+
+Sample Ansible Vault config:
+```
+vault:
+  vault_type: ansible-vault
+  vault_authentication_type: password-file
+  vault_password_file: /path/to/vault-password-file
+```
+
+**Note:** The password file should contain only the password (no newline at the end is recommended). You can create it using: `echo -n "your-secure-password" > /path/to/vault-password-file`
 
 ### Properties for `ibmcloud-vault`
 

--- a/sample-configurations/sample-dynamic/config-samples/vault-ansible-vault.yaml
+++ b/sample-configurations/sample-dynamic/config-samples/vault-ansible-vault.yaml
@@ -1,0 +1,14 @@
+---
+vault:
+  # Use ansible-vault as the vault type
+  vault_type: ansible-vault
+  
+  # Authentication type for ansible-vault is password-file
+  # This means you need to provide a file containing the vault password
+  vault_authentication_type: password-file
+  
+  # Path to the file containing the ansible-vault password
+  # This file should contain only the password (no newline at the end is recommended)
+  # Example: echo -n "your-secure-password" > /path/to/vault-password-file
+  vault_password_file: /path/to/vault-password-file
+


### PR DESCRIPTION
Implement Ansible Vault as a new vault type option, providing encrypted secret storage using Ansible's built-in vault functionality. This offers a good balance between security and ease of use without requiring external services like HashiCorp Vault or IBM Cloud Secrets Manager.

Key Changes:
- Add 'ansible-vault' as a new supported vault type
- Add 'password-file' authentication method for Ansible Vault
- Implement vault connection validation with password file checks
- Add encrypted secret storage and retrieval operations
- Include automatic retry logic with vault reconnection on failures

New Components:
- connect-ansible-vault.yml: Validates password file and connection
- get-secret-ansible-vault.yml: Decrypts and retrieves secrets securely
- create-secret-ansible-vault.yml: Encrypts and stores secrets
- vault-ansible-vault.yaml: Sample configuration file

Documentation:
- Update vault.md with Ansible Vault configuration details
- Add usage examples and password file creation instructions
- Document authentication requirements and best practices

Technical Implementation:
- Secrets stored in encrypted files under status_dir/vault/
- Uses temporary files for secure decrypt/encrypt operations
- Automatic cleanup of temporary decrypted content
- Base64 encoding for secret values
- Support for secret groups and individual secret management

Resolves: #735