### PR TITLE
Fix #1125: Change default log output to plain text without ANSI colors

### DIFF
--- a/cp-deploy.sh
+++ b/cp-deploy.sh
@@ -56,7 +56,7 @@ command_usage() {
   echo "  --clean-up                    Remove the container after the run is completed. Remove old images after build. (\$CPD_CLEANUP)"
   echo "  -v                            Show standard ansible output (\$ANSIBLE_STANDARD_OUTPUT)"
   echo "  -vv, -vvv, -vvvv, ...         Show verbose ansible output, verbose option used is (number of v)-1 (\$ANSIBLE_VERBOSE)"
-  echo "  --no-color                    Disable ANSI color codes in the output (\$CPD_NO_COLOR)"
+  echo "  --color                       Enable ANSI color codes in the output (\$CPD_NO_COLOR)"
   echo
   echo "Cloud Pak Deployer development options:"
   echo "  --cpd-develop                 Map current directory to automation scripts, only for development/debug (\$CPD_DEVELOP)"
@@ -118,7 +118,7 @@ if [ "${CPD_CLEANUP}" == "" ];then CPD_CLEANUP=false;fi
 if [ "${CPD_DEVELOP}" == "" ];then CPD_DEVELOP=false;fi
 if [ "${CPD_TEST_CARTRIDGES}" == "" ];then CPD_TEST_CARTRIDGES=false;fi
 if [ "${CPD_ACCEPT_LICENSES}" == "" ];then CPD_ACCEPT_LICENSES=false;fi
-if [ "${CPD_NO_COLOR}" == "" ];then CPD_NO_COLOR=false;fi
+if [ "${CPD_NO_COLOR}" == "" ];then CPD_NO_COLOR=true;fi
 if [ "${CPD_WIZARD_LOG_LEVEL}" == "" ];then CPD_WIZARD_LOG_LEVEL=INFO;fi
 
 # Check if the command is running inside a container. This means that the command should not start docker or podman
@@ -499,8 +499,8 @@ while (( "$#" )); do
     export CPD_SKIP_INFRA=true
     shift 1
     ;;
-  --no-color)
-    export CPD_NO_COLOR=true
+  --color)
+    export CPD_NO_COLOR=false
     shift 1
     ;;
   --skip-cp-install)

--- a/docs/src/10-use-deployer/3-run/existing-openshift.md
+++ b/docs/src/10-use-deployer/3-run/existing-openshift.md
@@ -217,6 +217,10 @@ cp-deploy.sh env apply --accept-all-licenses
 
 You can also specify extra variables such as `env_id` to override the names of the objects referenced in the `.yaml` configuration files as `{{ env_id }}-xxxx`. For more information about the extra (dynamic) variables, see [advanced configuration](../../../50-advanced/advanced-configuration).
 
+!!! info "Log output format"
+    By default, the deployer generates clean log files without ANSI color codes, making them easier to read and parse with external tools. If you prefer colored terminal output, you can enable it by adding the `--color` flag to the command.
+
+
 The `--accept-all-licenses` flag is optional and confirms that you accept all licenses of the installed cartridges and instances. Licenses must be either accepted in the configuration files or at the command line.
 
 When running the command, the container will start as a daemon and the command will tail-follow the logs. You can press Ctrl-C at any time to interrupt the logging but the container will continue to run in the background.


### PR DESCRIPTION
- Changed default CPD_NO_COLOR from false to true (colors disabled by default)
- Renamed --no-color flag to --color (inverted logic)
- Updated help text to reflect new --color flag
- Added documentation explaining new log output behavior
- Log files now clean and parseable by default
- Users can enable colored output with --color flag